### PR TITLE
Publish a deliverable podcast owner email

### DIFF
--- a/generate_podcast_feed.py
+++ b/generate_podcast_feed.py
@@ -191,7 +191,12 @@ def main():
     fg.podcast.itunes_summary(
         "Listen to the Westminster Confession and Catechisms in a year.  Based on Calendar of Readings in the Westminster Standards by Dr. Joey Pipa."
     )
-    fg.podcast.itunes_owner(name="Westminster Daily", email="tim@waiting-tables.com")
+    # Spotify, YouTube, and Amazon all prove feed ownership by mailing a code
+    # to this address, so it has to be deliverable. waiting-tables.com has no
+    # MX records at all; this one routes through Cloudflare Email Routing.
+    fg.podcast.itunes_owner(
+        name="Westminster Daily", email="podcast@reformedconfessions.com"
+    )
     fg.podcast.itunes_image("https://reformedconfessions.com/images/pulpit_full.png")
     fg.podcast.itunes_author("Westminster Daily")
     


### PR DESCRIPTION
## TL;DR

`<itunes:owner><itunes:email>` was `tim@waiting-tables.com`, and that domain has **no MX records** — the address cannot receive mail. Spotify, YouTube, and Amazon all prove feed ownership by mailing a verification code there, so submission to any of them would stall. Now publishes `podcast@reformedconfessions.com`, which routes to `t@ehop.me` via Cloudflare Email Routing on the podcast's own domain.

```
$ dig +short MX waiting-tables.com     -> (nothing)
$ dig +short MX waitingtables.org      -> (nothing)
$ dig +short MX reformedconfessions.com -> route2.mx.cloudflare.net, route3.mx.cloudflare.net
```

The routing rule is already live: `podcast@reformedconfessions.com -> t@ehop.me`, Active, alongside the existing `feedback@` rule.

Blocks the Spotify submission, which is otherwise ready — the feed now carries 365 items, sized enclosures, valid `itunes:explicit`, artwork, two categories, and a `podcast:guid`.
