### PR TITLE
Measure podcast downloads with an OP3 prefix

### DIFF
--- a/generate_podcast_feed.py
+++ b/generate_podcast_feed.py
@@ -47,6 +47,13 @@ NUMBER_OF_DAYS = 365
 # a future feed move would orphan it.
 PODCAST_GUID = "d9282da9-ef51-5b85-9393-1338eb8077af"
 
+# Downloads were entirely unmeasured: enclosures pointed straight at S3, so
+# the only numbers available were Apple's and Spotify's own slices. OP3 is a
+# free, open-source counting redirect (https://op3.dev) -- the player fetches
+# the prefixed URL, OP3 logs it and redirects to S3. Audio is still served
+# from the bucket; OP3 hosts nothing.
+OP3_PREFIX = f"https://op3.dev/e,pg={PODCAST_GUID}"
+
 
 @lru_cache()
 def markdown_parser(month, day):
@@ -149,6 +156,19 @@ def episode_title(month, day):
     return f"{' + '.join(citations)} — {title}"
 
 
+def op3_url(mp3_url):
+    """
+    Wrap an audio URL in the OP3 counting redirect.
+
+    OP3 wants the scheme stripped for https targets, so the published URL is
+    https://op3.dev/e,pg=<guid>/s3.amazonaws.com/... -- note this is only ever
+    applied to what goes in the feed. The build's own HEAD requests must keep
+    hitting S3 directly, or sizing 365 enclosures would register 365 downloads
+    every single build.
+    """
+    return f"{OP3_PREFIX}/{mp3_url.removeprefix('https://')}"
+
+
 def enclosure_length(mp3_url):
     """
     Look up the audio file's byte size.
@@ -244,7 +264,7 @@ def main():
 
         fe = fg.add_entry()
         fe.id(url)
-        fe.enclosure(mp3_for(date), length, "audio/mpeg")
+        fe.enclosure(op3_url(mp3_for(date)), length, "audio/mpeg")
         fe.title(episode_title(month, day))
         fe.link(href=url)
         fe.guid(guid, permalink=False)


### PR DESCRIPTION
## TL;DR

Enclosures pointed straight at S3, so podcast downloads were **entirely unmeasured** — the only numbers available were Apple's own slice and, as of today, Spotify's. Every other client was invisible. Routes enclosure URLs through [OP3](https://op3.dev), a free open-source counting redirect, so there's an actual download figure to point at.

```
before  https://s3.amazonaws.com/www.reformedconfessions.com/.../0801.mp3
after   https://op3.dev/e,pg=d9282da9-.../s3.amazonaws.com/www.reformedconfessions.com/.../0801.mp3
```

Audio is still served from the bucket. OP3 hosts nothing — it logs the request and 302s through.

## Reviewer notes

- **The build's HEAD requests deliberately bypass the prefix.** `enclosure_length()` sizes 365 enclosures on every build; routing those through OP3 would register 365 downloads per build and make the numbers worthless. `op3_url()` is applied only to what goes in the feed.
- **Scheme is stripped**, per OP3's setup docs — the prefix keeps `https://` only when the target is `http`. Ours is https, so the target appears bare.
- **`pg=` carries the show guid** (`PODCAST_GUID`, already declared as `<podcast:guid>`), so OP3 associates episodes with the right show rather than inferring one.
- **Guids are untouched**, so this is not a redelivery event. Existing subscribers simply start fetching through the redirect on their next poll. Prefixes are the standard mechanism here — Podtrac, Chartable, and Blubrry all work this way, and they stack if you ever add another.
- **The stats page is public**, and so is the API. Anyone can see the download counts. For a free unmonetized resource that's arguably useful — it's a number you can cite when emailing PCA CDM or the OPC.
- Not IAB-certified as far as I could confirm, so don't treat these as ad-grade figures. Moot here: the ESV terms forbid advertising on this domain anyway.

## Tests

Verified against the live redirect (which registers exactly one download):

| Check | Result |
|---|---|
| Enclosures in regenerated feed | 365 |
| All prefixed | yes |
| Zero-length enclosures | 0 — HEADs still reach S3 |
| `op3.dev/e,pg=...` → | `302` to the correct S3 object |
| Following through | `206`, `audio/mp3` |

## Follow-up

Timing is yours: Spotify is ingesting the back catalogue for the first time today, so it may be worth letting that settle before changing every enclosure URL. Nothing breaks either way.
