### PR TITLE
A readability pass over the site, plus the email link fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ build: og-images build/westminster-daily build/css/main.css ## Build site struct
 build/westminster-daily: ## Create Westminster Daily build directory
 	mkdir -p build/westminster-daily
 
-build/css/main.css: static/scss/main.scss package.json ## Compile SCSS to CSS
+# Depends on every partial, not just main.scss: custom.scss holds nearly all
+# the styling, and editing it alone used to leave the built CSS stale.
+build/css/main.css: $(wildcard static/scss/*.scss) package.json ## Compile SCSS to CSS
 	mkdir -p build/css/
 	npx sass --style=compressed --no-source-map static/scss/main.scss build/css/main.css
 

--- a/content/01/01.md
+++ b/content/01/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/31
 prev_date: Dec 31
 this_url: /westminster-daily/01/01
 short_date: "0101"
+day_number: "1"
 this_date: Jan 1
 next_url: /westminster-daily/01/02
 next_date: Jan 2

--- a/content/01/02.md
+++ b/content/01/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/01
 prev_date: Jan 1
 this_url: /westminster-daily/01/02
 short_date: "0102"
+day_number: "2"
 this_date: Jan 2
 next_url: /westminster-daily/01/03
 next_date: Jan 3

--- a/content/01/03.md
+++ b/content/01/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/02
 prev_date: Jan 2
 this_url: /westminster-daily/01/03
 short_date: "0103"
+day_number: "3"
 this_date: Jan 3
 next_url: /westminster-daily/01/04
 next_date: Jan 4

--- a/content/01/04.md
+++ b/content/01/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/03
 prev_date: Jan 3
 this_url: /westminster-daily/01/04
 short_date: "0104"
+day_number: "4"
 this_date: Jan 4
 next_url: /westminster-daily/01/05
 next_date: Jan 5

--- a/content/01/05.md
+++ b/content/01/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/04
 prev_date: Jan 4
 this_url: /westminster-daily/01/05
 short_date: "0105"
+day_number: "5"
 this_date: Jan 5
 next_url: /westminster-daily/01/06
 next_date: Jan 6

--- a/content/01/06.md
+++ b/content/01/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/05
 prev_date: Jan 5
 this_url: /westminster-daily/01/06
 short_date: "0106"
+day_number: "6"
 this_date: Jan 6
 next_url: /westminster-daily/01/07
 next_date: Jan 7

--- a/content/01/07.md
+++ b/content/01/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/06
 prev_date: Jan 6
 this_url: /westminster-daily/01/07
 short_date: "0107"
+day_number: "7"
 this_date: Jan 7
 next_url: /westminster-daily/01/08
 next_date: Jan 8

--- a/content/01/08.md
+++ b/content/01/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/07
 prev_date: Jan 7
 this_url: /westminster-daily/01/08
 short_date: "0108"
+day_number: "8"
 this_date: Jan 8
 next_url: /westminster-daily/01/09
 next_date: Jan 9

--- a/content/01/09.md
+++ b/content/01/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/08
 prev_date: Jan 8
 this_url: /westminster-daily/01/09
 short_date: "0109"
+day_number: "9"
 this_date: Jan 9
 next_url: /westminster-daily/01/10
 next_date: Jan 10

--- a/content/01/10.md
+++ b/content/01/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/09
 prev_date: Jan 9
 this_url: /westminster-daily/01/10
 short_date: "0110"
+day_number: "10"
 this_date: Jan 10
 next_url: /westminster-daily/01/11
 next_date: Jan 11

--- a/content/01/11.md
+++ b/content/01/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/10
 prev_date: Jan 10
 this_url: /westminster-daily/01/11
 short_date: "0111"
+day_number: "11"
 this_date: Jan 11
 next_url: /westminster-daily/01/12
 next_date: Jan 12

--- a/content/01/12.md
+++ b/content/01/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/11
 prev_date: Jan 11
 this_url: /westminster-daily/01/12
 short_date: "0112"
+day_number: "12"
 this_date: Jan 12
 next_url: /westminster-daily/01/13
 next_date: Jan 13

--- a/content/01/13.md
+++ b/content/01/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/12
 prev_date: Jan 12
 this_url: /westminster-daily/01/13
 short_date: "0113"
+day_number: "13"
 this_date: Jan 13
 next_url: /westminster-daily/01/14
 next_date: Jan 14

--- a/content/01/14.md
+++ b/content/01/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/13
 prev_date: Jan 13
 this_url: /westminster-daily/01/14
 short_date: "0114"
+day_number: "14"
 this_date: Jan 14
 next_url: /westminster-daily/01/15
 next_date: Jan 15

--- a/content/01/15.md
+++ b/content/01/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/14
 prev_date: Jan 14
 this_url: /westminster-daily/01/15
 short_date: "0115"
+day_number: "15"
 this_date: Jan 15
 next_url: /westminster-daily/01/16
 next_date: Jan 16

--- a/content/01/16.md
+++ b/content/01/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/15
 prev_date: Jan 15
 this_url: /westminster-daily/01/16
 short_date: "0116"
+day_number: "16"
 this_date: Jan 16
 next_url: /westminster-daily/01/17
 next_date: Jan 17

--- a/content/01/17.md
+++ b/content/01/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/16
 prev_date: Jan 16
 this_url: /westminster-daily/01/17
 short_date: "0117"
+day_number: "17"
 this_date: Jan 17
 next_url: /westminster-daily/01/18
 next_date: Jan 18

--- a/content/01/18.md
+++ b/content/01/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/17
 prev_date: Jan 17
 this_url: /westminster-daily/01/18
 short_date: "0118"
+day_number: "18"
 this_date: Jan 18
 next_url: /westminster-daily/01/19
 next_date: Jan 19

--- a/content/01/19.md
+++ b/content/01/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/18
 prev_date: Jan 18
 this_url: /westminster-daily/01/19
 short_date: "0119"
+day_number: "19"
 this_date: Jan 19
 next_url: /westminster-daily/01/20
 next_date: Jan 20

--- a/content/01/20.md
+++ b/content/01/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/19
 prev_date: Jan 19
 this_url: /westminster-daily/01/20
 short_date: "0120"
+day_number: "20"
 this_date: Jan 20
 next_url: /westminster-daily/01/21
 next_date: Jan 21

--- a/content/01/21.md
+++ b/content/01/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/20
 prev_date: Jan 20
 this_url: /westminster-daily/01/21
 short_date: "0121"
+day_number: "21"
 this_date: Jan 21
 next_url: /westminster-daily/01/22
 next_date: Jan 22

--- a/content/01/22.md
+++ b/content/01/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/21
 prev_date: Jan 21
 this_url: /westminster-daily/01/22
 short_date: "0122"
+day_number: "22"
 this_date: Jan 22
 next_url: /westminster-daily/01/23
 next_date: Jan 23

--- a/content/01/23.md
+++ b/content/01/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/22
 prev_date: Jan 22
 this_url: /westminster-daily/01/23
 short_date: "0123"
+day_number: "23"
 this_date: Jan 23
 next_url: /westminster-daily/01/24
 next_date: Jan 24

--- a/content/01/24.md
+++ b/content/01/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/23
 prev_date: Jan 23
 this_url: /westminster-daily/01/24
 short_date: "0124"
+day_number: "24"
 this_date: Jan 24
 next_url: /westminster-daily/01/25
 next_date: Jan 25

--- a/content/01/25.md
+++ b/content/01/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/24
 prev_date: Jan 24
 this_url: /westminster-daily/01/25
 short_date: "0125"
+day_number: "25"
 this_date: Jan 25
 next_url: /westminster-daily/01/26
 next_date: Jan 26

--- a/content/01/26.md
+++ b/content/01/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/25
 prev_date: Jan 25
 this_url: /westminster-daily/01/26
 short_date: "0126"
+day_number: "26"
 this_date: Jan 26
 next_url: /westminster-daily/01/27
 next_date: Jan 27

--- a/content/01/27.md
+++ b/content/01/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/26
 prev_date: Jan 26
 this_url: /westminster-daily/01/27
 short_date: "0127"
+day_number: "27"
 this_date: Jan 27
 next_url: /westminster-daily/01/28
 next_date: Jan 28

--- a/content/01/28.md
+++ b/content/01/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/27
 prev_date: Jan 27
 this_url: /westminster-daily/01/28
 short_date: "0128"
+day_number: "28"
 this_date: Jan 28
 next_url: /westminster-daily/01/29
 next_date: Jan 29

--- a/content/01/29.md
+++ b/content/01/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/28
 prev_date: Jan 28
 this_url: /westminster-daily/01/29
 short_date: "0129"
+day_number: "29"
 this_date: Jan 29
 next_url: /westminster-daily/01/30
 next_date: Jan 30

--- a/content/01/30.md
+++ b/content/01/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/29
 prev_date: Jan 29
 this_url: /westminster-daily/01/30
 short_date: "0130"
+day_number: "30"
 this_date: Jan 30
 next_url: /westminster-daily/01/31
 next_date: Jan 31

--- a/content/01/31.md
+++ b/content/01/31.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/30
 prev_date: Jan 30
 this_url: /westminster-daily/01/31
 short_date: "0131"
+day_number: "31"
 this_date: Jan 31
 next_url: /westminster-daily/02/01
 next_date: Feb 1

--- a/content/02/01.md
+++ b/content/02/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/01/31
 prev_date: Jan 31
 this_url: /westminster-daily/02/01
 short_date: "0201"
+day_number: "32"
 this_date: Feb 1
 next_url: /westminster-daily/02/02
 next_date: Feb 2

--- a/content/02/02.md
+++ b/content/02/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/01
 prev_date: Feb 1
 this_url: /westminster-daily/02/02
 short_date: "0202"
+day_number: "33"
 this_date: Feb 2
 next_url: /westminster-daily/02/03
 next_date: Feb 3

--- a/content/02/03.md
+++ b/content/02/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/02
 prev_date: Feb 2
 this_url: /westminster-daily/02/03
 short_date: "0203"
+day_number: "34"
 this_date: Feb 3
 next_url: /westminster-daily/02/04
 next_date: Feb 4

--- a/content/02/04.md
+++ b/content/02/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/03
 prev_date: Feb 3
 this_url: /westminster-daily/02/04
 short_date: "0204"
+day_number: "35"
 this_date: Feb 4
 next_url: /westminster-daily/02/05
 next_date: Feb 5

--- a/content/02/05.md
+++ b/content/02/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/04
 prev_date: Feb 4
 this_url: /westminster-daily/02/05
 short_date: "0205"
+day_number: "36"
 this_date: Feb 5
 next_url: /westminster-daily/02/06
 next_date: Feb 6

--- a/content/02/06.md
+++ b/content/02/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/05
 prev_date: Feb 5
 this_url: /westminster-daily/02/06
 short_date: "0206"
+day_number: "37"
 this_date: Feb 6
 next_url: /westminster-daily/02/07
 next_date: Feb 7

--- a/content/02/07.md
+++ b/content/02/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/06
 prev_date: Feb 6
 this_url: /westminster-daily/02/07
 short_date: "0207"
+day_number: "38"
 this_date: Feb 7
 next_url: /westminster-daily/02/08
 next_date: Feb 8

--- a/content/02/08.md
+++ b/content/02/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/07
 prev_date: Feb 7
 this_url: /westminster-daily/02/08
 short_date: "0208"
+day_number: "39"
 this_date: Feb 8
 next_url: /westminster-daily/02/09
 next_date: Feb 9

--- a/content/02/09.md
+++ b/content/02/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/08
 prev_date: Feb 8
 this_url: /westminster-daily/02/09
 short_date: "0209"
+day_number: "40"
 this_date: Feb 9
 next_url: /westminster-daily/02/10
 next_date: Feb 10

--- a/content/02/10.md
+++ b/content/02/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/09
 prev_date: Feb 9
 this_url: /westminster-daily/02/10
 short_date: "0210"
+day_number: "41"
 this_date: Feb 10
 next_url: /westminster-daily/02/11
 next_date: Feb 11

--- a/content/02/11.md
+++ b/content/02/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/10
 prev_date: Feb 10
 this_url: /westminster-daily/02/11
 short_date: "0211"
+day_number: "42"
 this_date: Feb 11
 next_url: /westminster-daily/02/12
 next_date: Feb 12

--- a/content/02/12.md
+++ b/content/02/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/11
 prev_date: Feb 11
 this_url: /westminster-daily/02/12
 short_date: "0212"
+day_number: "43"
 this_date: Feb 12
 next_url: /westminster-daily/02/13
 next_date: Feb 13

--- a/content/02/13.md
+++ b/content/02/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/12
 prev_date: Feb 12
 this_url: /westminster-daily/02/13
 short_date: "0213"
+day_number: "44"
 this_date: Feb 13
 next_url: /westminster-daily/02/14
 next_date: Feb 14

--- a/content/02/14.md
+++ b/content/02/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/13
 prev_date: Feb 13
 this_url: /westminster-daily/02/14
 short_date: "0214"
+day_number: "45"
 this_date: Feb 14
 next_url: /westminster-daily/02/15
 next_date: Feb 15

--- a/content/02/15.md
+++ b/content/02/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/14
 prev_date: Feb 14
 this_url: /westminster-daily/02/15
 short_date: "0215"
+day_number: "46"
 this_date: Feb 15
 next_url: /westminster-daily/02/16
 next_date: Feb 16

--- a/content/02/16.md
+++ b/content/02/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/15
 prev_date: Feb 15
 this_url: /westminster-daily/02/16
 short_date: "0216"
+day_number: "47"
 this_date: Feb 16
 next_url: /westminster-daily/02/17
 next_date: Feb 17

--- a/content/02/17.md
+++ b/content/02/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/16
 prev_date: Feb 16
 this_url: /westminster-daily/02/17
 short_date: "0217"
+day_number: "48"
 this_date: Feb 17
 next_url: /westminster-daily/02/18
 next_date: Feb 18

--- a/content/02/18.md
+++ b/content/02/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/17
 prev_date: Feb 17
 this_url: /westminster-daily/02/18
 short_date: "0218"
+day_number: "49"
 this_date: Feb 18
 next_url: /westminster-daily/02/19
 next_date: Feb 19

--- a/content/02/19.md
+++ b/content/02/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/18
 prev_date: Feb 18
 this_url: /westminster-daily/02/19
 short_date: "0219"
+day_number: "50"
 this_date: Feb 19
 next_url: /westminster-daily/02/20
 next_date: Feb 20

--- a/content/02/20.md
+++ b/content/02/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/19
 prev_date: Feb 19
 this_url: /westminster-daily/02/20
 short_date: "0220"
+day_number: "51"
 this_date: Feb 20
 next_url: /westminster-daily/02/21
 next_date: Feb 21

--- a/content/02/21.md
+++ b/content/02/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/20
 prev_date: Feb 20
 this_url: /westminster-daily/02/21
 short_date: "0221"
+day_number: "52"
 this_date: Feb 21
 next_url: /westminster-daily/02/22
 next_date: Feb 22

--- a/content/02/22.md
+++ b/content/02/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/21
 prev_date: Feb 21
 this_url: /westminster-daily/02/22
 short_date: "0222"
+day_number: "53"
 this_date: Feb 22
 next_url: /westminster-daily/02/23
 next_date: Feb 23

--- a/content/02/23.md
+++ b/content/02/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/22
 prev_date: Feb 22
 this_url: /westminster-daily/02/23
 short_date: "0223"
+day_number: "54"
 this_date: Feb 23
 next_url: /westminster-daily/02/24
 next_date: Feb 24

--- a/content/02/24.md
+++ b/content/02/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/23
 prev_date: Feb 23
 this_url: /westminster-daily/02/24
 short_date: "0224"
+day_number: "55"
 this_date: Feb 24
 next_url: /westminster-daily/02/25
 next_date: Feb 25

--- a/content/02/25.md
+++ b/content/02/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/24
 prev_date: Feb 24
 this_url: /westminster-daily/02/25
 short_date: "0225"
+day_number: "56"
 this_date: Feb 25
 next_url: /westminster-daily/02/26
 next_date: Feb 26

--- a/content/02/26.md
+++ b/content/02/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/25
 prev_date: Feb 25
 this_url: /westminster-daily/02/26
 short_date: "0226"
+day_number: "57"
 this_date: Feb 26
 next_url: /westminster-daily/02/27
 next_date: Feb 27

--- a/content/02/27.md
+++ b/content/02/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/26
 prev_date: Feb 26
 this_url: /westminster-daily/02/27
 short_date: "0227"
+day_number: "58"
 this_date: Feb 27
 next_url: /westminster-daily/02/28
 next_date: Feb 28

--- a/content/02/28.md
+++ b/content/02/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/27
 prev_date: Feb 27
 this_url: /westminster-daily/02/28
 short_date: "0228"
+day_number: "59"
 this_date: Feb 28
 next_url: /westminster-daily/02/29
 next_date: Feb 29

--- a/content/02/29.md
+++ b/content/02/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/28
 prev_date: Feb 28
 this_url: /westminster-daily/02/29
 short_date: "0229"
+day_number: "60"
 this_date: Feb 29
 next_url: /westminster-daily/03/01
 next_date: Mar 1

--- a/content/03/01.md
+++ b/content/03/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/02/29
 prev_date: Feb 29
 this_url: /westminster-daily/03/01
 short_date: "0301"
+day_number: "60"
 this_date: Mar 1
 next_url: /westminster-daily/03/02
 next_date: Mar 2

--- a/content/03/02.md
+++ b/content/03/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/01
 prev_date: Mar 1
 this_url: /westminster-daily/03/02
 short_date: "0302"
+day_number: "61"
 this_date: Mar 2
 next_url: /westminster-daily/03/03
 next_date: Mar 3

--- a/content/03/03.md
+++ b/content/03/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/02
 prev_date: Mar 2
 this_url: /westminster-daily/03/03
 short_date: "0303"
+day_number: "62"
 this_date: Mar 3
 next_url: /westminster-daily/03/04
 next_date: Mar 4

--- a/content/03/04.md
+++ b/content/03/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/03
 prev_date: Mar 3
 this_url: /westminster-daily/03/04
 short_date: "0304"
+day_number: "63"
 this_date: Mar 4
 next_url: /westminster-daily/03/05
 next_date: Mar 5

--- a/content/03/05.md
+++ b/content/03/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/04
 prev_date: Mar 4
 this_url: /westminster-daily/03/05
 short_date: "0305"
+day_number: "64"
 this_date: Mar 5
 next_url: /westminster-daily/03/06
 next_date: Mar 6

--- a/content/03/06.md
+++ b/content/03/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/05
 prev_date: Mar 5
 this_url: /westminster-daily/03/06
 short_date: "0306"
+day_number: "65"
 this_date: Mar 6
 next_url: /westminster-daily/03/07
 next_date: Mar 7

--- a/content/03/07.md
+++ b/content/03/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/06
 prev_date: Mar 6
 this_url: /westminster-daily/03/07
 short_date: "0307"
+day_number: "66"
 this_date: Mar 7
 next_url: /westminster-daily/03/08
 next_date: Mar 8

--- a/content/03/08.md
+++ b/content/03/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/07
 prev_date: Mar 7
 this_url: /westminster-daily/03/08
 short_date: "0308"
+day_number: "67"
 this_date: Mar 8
 next_url: /westminster-daily/03/09
 next_date: Mar 9

--- a/content/03/09.md
+++ b/content/03/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/08
 prev_date: Mar 8
 this_url: /westminster-daily/03/09
 short_date: "0309"
+day_number: "68"
 this_date: Mar 9
 next_url: /westminster-daily/03/10
 next_date: Mar 10

--- a/content/03/10.md
+++ b/content/03/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/09
 prev_date: Mar 9
 this_url: /westminster-daily/03/10
 short_date: "0310"
+day_number: "69"
 this_date: Mar 10
 next_url: /westminster-daily/03/11
 next_date: Mar 11

--- a/content/03/11.md
+++ b/content/03/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/10
 prev_date: Mar 10
 this_url: /westminster-daily/03/11
 short_date: "0311"
+day_number: "70"
 this_date: Mar 11
 next_url: /westminster-daily/03/12
 next_date: Mar 12

--- a/content/03/12.md
+++ b/content/03/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/11
 prev_date: Mar 11
 this_url: /westminster-daily/03/12
 short_date: "0312"
+day_number: "71"
 this_date: Mar 12
 next_url: /westminster-daily/03/13
 next_date: Mar 13

--- a/content/03/13.md
+++ b/content/03/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/12
 prev_date: Mar 12
 this_url: /westminster-daily/03/13
 short_date: "0313"
+day_number: "72"
 this_date: Mar 13
 next_url: /westminster-daily/03/14
 next_date: Mar 14

--- a/content/03/14.md
+++ b/content/03/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/13
 prev_date: Mar 13
 this_url: /westminster-daily/03/14
 short_date: "0314"
+day_number: "73"
 this_date: Mar 14
 next_url: /westminster-daily/03/15
 next_date: Mar 15

--- a/content/03/15.md
+++ b/content/03/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/14
 prev_date: Mar 14
 this_url: /westminster-daily/03/15
 short_date: "0315"
+day_number: "74"
 this_date: Mar 15
 next_url: /westminster-daily/03/16
 next_date: Mar 16

--- a/content/03/16.md
+++ b/content/03/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/15
 prev_date: Mar 15
 this_url: /westminster-daily/03/16
 short_date: "0316"
+day_number: "75"
 this_date: Mar 16
 next_url: /westminster-daily/03/17
 next_date: Mar 17

--- a/content/03/17.md
+++ b/content/03/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/16
 prev_date: Mar 16
 this_url: /westminster-daily/03/17
 short_date: "0317"
+day_number: "76"
 this_date: Mar 17
 next_url: /westminster-daily/03/18
 next_date: Mar 18

--- a/content/03/18.md
+++ b/content/03/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/17
 prev_date: Mar 17
 this_url: /westminster-daily/03/18
 short_date: "0318"
+day_number: "77"
 this_date: Mar 18
 next_url: /westminster-daily/03/19
 next_date: Mar 19

--- a/content/03/19.md
+++ b/content/03/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/18
 prev_date: Mar 18
 this_url: /westminster-daily/03/19
 short_date: "0319"
+day_number: "78"
 this_date: Mar 19
 next_url: /westminster-daily/03/20
 next_date: Mar 20

--- a/content/03/20.md
+++ b/content/03/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/19
 prev_date: Mar 19
 this_url: /westminster-daily/03/20
 short_date: "0320"
+day_number: "79"
 this_date: Mar 20
 next_url: /westminster-daily/03/21
 next_date: Mar 21

--- a/content/03/21.md
+++ b/content/03/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/20
 prev_date: Mar 20
 this_url: /westminster-daily/03/21
 short_date: "0321"
+day_number: "80"
 this_date: Mar 21
 next_url: /westminster-daily/03/22
 next_date: Mar 22

--- a/content/03/22.md
+++ b/content/03/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/21
 prev_date: Mar 21
 this_url: /westminster-daily/03/22
 short_date: "0322"
+day_number: "81"
 this_date: Mar 22
 next_url: /westminster-daily/03/23
 next_date: Mar 23

--- a/content/03/23.md
+++ b/content/03/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/22
 prev_date: Mar 22
 this_url: /westminster-daily/03/23
 short_date: "0323"
+day_number: "82"
 this_date: Mar 23
 next_url: /westminster-daily/03/24
 next_date: Mar 24

--- a/content/03/24.md
+++ b/content/03/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/23
 prev_date: Mar 23
 this_url: /westminster-daily/03/24
 short_date: "0324"
+day_number: "83"
 this_date: Mar 24
 next_url: /westminster-daily/03/25
 next_date: Mar 25

--- a/content/03/25.md
+++ b/content/03/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/24
 prev_date: Mar 24
 this_url: /westminster-daily/03/25
 short_date: "0325"
+day_number: "84"
 this_date: Mar 25
 next_url: /westminster-daily/03/26
 next_date: Mar 26

--- a/content/03/26.md
+++ b/content/03/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/25
 prev_date: Mar 25
 this_url: /westminster-daily/03/26
 short_date: "0326"
+day_number: "85"
 this_date: Mar 26
 next_url: /westminster-daily/03/27
 next_date: Mar 27

--- a/content/03/27.md
+++ b/content/03/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/26
 prev_date: Mar 26
 this_url: /westminster-daily/03/27
 short_date: "0327"
+day_number: "86"
 this_date: Mar 27
 next_url: /westminster-daily/03/28
 next_date: Mar 28

--- a/content/03/28.md
+++ b/content/03/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/27
 prev_date: Mar 27
 this_url: /westminster-daily/03/28
 short_date: "0328"
+day_number: "87"
 this_date: Mar 28
 next_url: /westminster-daily/03/29
 next_date: Mar 29

--- a/content/03/29.md
+++ b/content/03/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/28
 prev_date: Mar 28
 this_url: /westminster-daily/03/29
 short_date: "0329"
+day_number: "88"
 this_date: Mar 29
 next_url: /westminster-daily/03/30
 next_date: Mar 30

--- a/content/03/30.md
+++ b/content/03/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/29
 prev_date: Mar 29
 this_url: /westminster-daily/03/30
 short_date: "0330"
+day_number: "89"
 this_date: Mar 30
 next_url: /westminster-daily/03/31
 next_date: Mar 31

--- a/content/03/31.md
+++ b/content/03/31.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/30
 prev_date: Mar 30
 this_url: /westminster-daily/03/31
 short_date: "0331"
+day_number: "90"
 this_date: Mar 31
 next_url: /westminster-daily/04/01
 next_date: Apr 1

--- a/content/04/01.md
+++ b/content/04/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/03/31
 prev_date: Mar 31
 this_url: /westminster-daily/04/01
 short_date: "0401"
+day_number: "91"
 this_date: Apr 1
 next_url: /westminster-daily/04/02
 next_date: Apr 2

--- a/content/04/02.md
+++ b/content/04/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/01
 prev_date: Apr 1
 this_url: /westminster-daily/04/02
 short_date: "0402"
+day_number: "92"
 this_date: Apr 2
 next_url: /westminster-daily/04/03
 next_date: Apr 3

--- a/content/04/03.md
+++ b/content/04/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/02
 prev_date: Apr 2
 this_url: /westminster-daily/04/03
 short_date: "0403"
+day_number: "93"
 this_date: Apr 3
 next_url: /westminster-daily/04/04
 next_date: Apr 4

--- a/content/04/04.md
+++ b/content/04/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/03
 prev_date: Apr 3
 this_url: /westminster-daily/04/04
 short_date: "0404"
+day_number: "94"
 this_date: Apr 4
 next_url: /westminster-daily/04/05
 next_date: Apr 5

--- a/content/04/05.md
+++ b/content/04/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/04
 prev_date: Apr 4
 this_url: /westminster-daily/04/05
 short_date: "0405"
+day_number: "95"
 this_date: Apr 5
 next_url: /westminster-daily/04/06
 next_date: Apr 6

--- a/content/04/06.md
+++ b/content/04/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/05
 prev_date: Apr 5
 this_url: /westminster-daily/04/06
 short_date: "0406"
+day_number: "96"
 this_date: Apr 6
 next_url: /westminster-daily/04/07
 next_date: Apr 7

--- a/content/04/07.md
+++ b/content/04/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/06
 prev_date: Apr 6
 this_url: /westminster-daily/04/07
 short_date: "0407"
+day_number: "97"
 this_date: Apr 7
 next_url: /westminster-daily/04/08
 next_date: Apr 8

--- a/content/04/08.md
+++ b/content/04/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/07
 prev_date: Apr 7
 this_url: /westminster-daily/04/08
 short_date: "0408"
+day_number: "98"
 this_date: Apr 8
 next_url: /westminster-daily/04/09
 next_date: Apr 9

--- a/content/04/09.md
+++ b/content/04/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/08
 prev_date: Apr 8
 this_url: /westminster-daily/04/09
 short_date: "0409"
+day_number: "99"
 this_date: Apr 9
 next_url: /westminster-daily/04/10
 next_date: Apr 10

--- a/content/04/10.md
+++ b/content/04/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/09
 prev_date: Apr 9
 this_url: /westminster-daily/04/10
 short_date: "0410"
+day_number: "100"
 this_date: Apr 10
 next_url: /westminster-daily/04/11
 next_date: Apr 11

--- a/content/04/11.md
+++ b/content/04/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/10
 prev_date: Apr 10
 this_url: /westminster-daily/04/11
 short_date: "0411"
+day_number: "101"
 this_date: Apr 11
 next_url: /westminster-daily/04/12
 next_date: Apr 12

--- a/content/04/12.md
+++ b/content/04/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/11
 prev_date: Apr 11
 this_url: /westminster-daily/04/12
 short_date: "0412"
+day_number: "102"
 this_date: Apr 12
 next_url: /westminster-daily/04/13
 next_date: Apr 13

--- a/content/04/13.md
+++ b/content/04/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/12
 prev_date: Apr 12
 this_url: /westminster-daily/04/13
 short_date: "0413"
+day_number: "103"
 this_date: Apr 13
 next_url: /westminster-daily/04/14
 next_date: Apr 14

--- a/content/04/14.md
+++ b/content/04/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/13
 prev_date: Apr 13
 this_url: /westminster-daily/04/14
 short_date: "0414"
+day_number: "104"
 this_date: Apr 14
 next_url: /westminster-daily/04/15
 next_date: Apr 15

--- a/content/04/15.md
+++ b/content/04/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/14
 prev_date: Apr 14
 this_url: /westminster-daily/04/15
 short_date: "0415"
+day_number: "105"
 this_date: Apr 15
 next_url: /westminster-daily/04/16
 next_date: Apr 16

--- a/content/04/16.md
+++ b/content/04/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/15
 prev_date: Apr 15
 this_url: /westminster-daily/04/16
 short_date: "0416"
+day_number: "106"
 this_date: Apr 16
 next_url: /westminster-daily/04/17
 next_date: Apr 17

--- a/content/04/17.md
+++ b/content/04/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/16
 prev_date: Apr 16
 this_url: /westminster-daily/04/17
 short_date: "0417"
+day_number: "107"
 this_date: Apr 17
 next_url: /westminster-daily/04/18
 next_date: Apr 18

--- a/content/04/18.md
+++ b/content/04/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/17
 prev_date: Apr 17
 this_url: /westminster-daily/04/18
 short_date: "0418"
+day_number: "108"
 this_date: Apr 18
 next_url: /westminster-daily/04/19
 next_date: Apr 19

--- a/content/04/19.md
+++ b/content/04/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/18
 prev_date: Apr 18
 this_url: /westminster-daily/04/19
 short_date: "0419"
+day_number: "109"
 this_date: Apr 19
 next_url: /westminster-daily/04/20
 next_date: Apr 20

--- a/content/04/20.md
+++ b/content/04/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/19
 prev_date: Apr 19
 this_url: /westminster-daily/04/20
 short_date: "0420"
+day_number: "110"
 this_date: Apr 20
 next_url: /westminster-daily/04/21
 next_date: Apr 21

--- a/content/04/21.md
+++ b/content/04/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/20
 prev_date: Apr 20
 this_url: /westminster-daily/04/21
 short_date: "0421"
+day_number: "111"
 this_date: Apr 21
 next_url: /westminster-daily/04/22
 next_date: Apr 22

--- a/content/04/22.md
+++ b/content/04/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/21
 prev_date: Apr 21
 this_url: /westminster-daily/04/22
 short_date: "0422"
+day_number: "112"
 this_date: Apr 22
 next_url: /westminster-daily/04/23
 next_date: Apr 23

--- a/content/04/23.md
+++ b/content/04/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/22
 prev_date: Apr 22
 this_url: /westminster-daily/04/23
 short_date: "0423"
+day_number: "113"
 this_date: Apr 23
 next_url: /westminster-daily/04/24
 next_date: Apr 24

--- a/content/04/24.md
+++ b/content/04/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/23
 prev_date: Apr 23
 this_url: /westminster-daily/04/24
 short_date: "0424"
+day_number: "114"
 this_date: Apr 24
 next_url: /westminster-daily/04/25
 next_date: Apr 25

--- a/content/04/25.md
+++ b/content/04/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/24
 prev_date: Apr 24
 this_url: /westminster-daily/04/25
 short_date: "0425"
+day_number: "115"
 this_date: Apr 25
 next_url: /westminster-daily/04/26
 next_date: Apr 26

--- a/content/04/26.md
+++ b/content/04/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/25
 prev_date: Apr 25
 this_url: /westminster-daily/04/26
 short_date: "0426"
+day_number: "116"
 this_date: Apr 26
 next_url: /westminster-daily/04/27
 next_date: Apr 27

--- a/content/04/27.md
+++ b/content/04/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/26
 prev_date: Apr 26
 this_url: /westminster-daily/04/27
 short_date: "0427"
+day_number: "117"
 this_date: Apr 27
 next_url: /westminster-daily/04/28
 next_date: Apr 28

--- a/content/04/28.md
+++ b/content/04/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/27
 prev_date: Apr 27
 this_url: /westminster-daily/04/28
 short_date: "0428"
+day_number: "118"
 this_date: Apr 28
 next_url: /westminster-daily/04/29
 next_date: Apr 29

--- a/content/04/29.md
+++ b/content/04/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/28
 prev_date: Apr 28
 this_url: /westminster-daily/04/29
 short_date: "0429"
+day_number: "119"
 this_date: Apr 29
 next_url: /westminster-daily/04/30
 next_date: Apr 30

--- a/content/04/30.md
+++ b/content/04/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/29
 prev_date: Apr 29
 this_url: /westminster-daily/04/30
 short_date: "0430"
+day_number: "120"
 this_date: Apr 30
 next_url: /westminster-daily/05/01
 next_date: May 1

--- a/content/05/01.md
+++ b/content/05/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/04/30
 prev_date: Apr 30
 this_url: /westminster-daily/05/01
 short_date: "0501"
+day_number: "121"
 this_date: May 1
 next_url: /westminster-daily/05/02
 next_date: May 2

--- a/content/05/02.md
+++ b/content/05/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/01
 prev_date: May 1
 this_url: /westminster-daily/05/02
 short_date: "0502"
+day_number: "122"
 this_date: May 2
 next_url: /westminster-daily/05/03
 next_date: May 3

--- a/content/05/03.md
+++ b/content/05/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/02
 prev_date: May 2
 this_url: /westminster-daily/05/03
 short_date: "0503"
+day_number: "123"
 this_date: May 3
 next_url: /westminster-daily/05/04
 next_date: May 4

--- a/content/05/04.md
+++ b/content/05/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/03
 prev_date: May 3
 this_url: /westminster-daily/05/04
 short_date: "0504"
+day_number: "124"
 this_date: May 4
 next_url: /westminster-daily/05/05
 next_date: May 5

--- a/content/05/05.md
+++ b/content/05/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/04
 prev_date: May 4
 this_url: /westminster-daily/05/05
 short_date: "0505"
+day_number: "125"
 this_date: May 5
 next_url: /westminster-daily/05/06
 next_date: May 6

--- a/content/05/06.md
+++ b/content/05/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/05
 prev_date: May 5
 this_url: /westminster-daily/05/06
 short_date: "0506"
+day_number: "126"
 this_date: May 6
 next_url: /westminster-daily/05/07
 next_date: May 7

--- a/content/05/07.md
+++ b/content/05/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/06
 prev_date: May 6
 this_url: /westminster-daily/05/07
 short_date: "0507"
+day_number: "127"
 this_date: May 7
 next_url: /westminster-daily/05/08
 next_date: May 8

--- a/content/05/08.md
+++ b/content/05/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/07
 prev_date: May 7
 this_url: /westminster-daily/05/08
 short_date: "0508"
+day_number: "128"
 this_date: May 8
 next_url: /westminster-daily/05/09
 next_date: May 9

--- a/content/05/09.md
+++ b/content/05/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/08
 prev_date: May 8
 this_url: /westminster-daily/05/09
 short_date: "0509"
+day_number: "129"
 this_date: May 9
 next_url: /westminster-daily/05/10
 next_date: May 10

--- a/content/05/10.md
+++ b/content/05/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/09
 prev_date: May 9
 this_url: /westminster-daily/05/10
 short_date: "0510"
+day_number: "130"
 this_date: May 10
 next_url: /westminster-daily/05/11
 next_date: May 11

--- a/content/05/11.md
+++ b/content/05/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/10
 prev_date: May 10
 this_url: /westminster-daily/05/11
 short_date: "0511"
+day_number: "131"
 this_date: May 11
 next_url: /westminster-daily/05/12
 next_date: May 12

--- a/content/05/12.md
+++ b/content/05/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/11
 prev_date: May 11
 this_url: /westminster-daily/05/12
 short_date: "0512"
+day_number: "132"
 this_date: May 12
 next_url: /westminster-daily/05/13
 next_date: May 13

--- a/content/05/13.md
+++ b/content/05/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/12
 prev_date: May 12
 this_url: /westminster-daily/05/13
 short_date: "0513"
+day_number: "133"
 this_date: May 13
 next_url: /westminster-daily/05/14
 next_date: May 14

--- a/content/05/14.md
+++ b/content/05/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/13
 prev_date: May 13
 this_url: /westminster-daily/05/14
 short_date: "0514"
+day_number: "134"
 this_date: May 14
 next_url: /westminster-daily/05/15
 next_date: May 15

--- a/content/05/15.md
+++ b/content/05/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/14
 prev_date: May 14
 this_url: /westminster-daily/05/15
 short_date: "0515"
+day_number: "135"
 this_date: May 15
 next_url: /westminster-daily/05/16
 next_date: May 16

--- a/content/05/16.md
+++ b/content/05/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/15
 prev_date: May 15
 this_url: /westminster-daily/05/16
 short_date: "0516"
+day_number: "136"
 this_date: May 16
 next_url: /westminster-daily/05/17
 next_date: May 17

--- a/content/05/17.md
+++ b/content/05/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/16
 prev_date: May 16
 this_url: /westminster-daily/05/17
 short_date: "0517"
+day_number: "137"
 this_date: May 17
 next_url: /westminster-daily/05/18
 next_date: May 18

--- a/content/05/18.md
+++ b/content/05/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/17
 prev_date: May 17
 this_url: /westminster-daily/05/18
 short_date: "0518"
+day_number: "138"
 this_date: May 18
 next_url: /westminster-daily/05/19
 next_date: May 19

--- a/content/05/19.md
+++ b/content/05/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/18
 prev_date: May 18
 this_url: /westminster-daily/05/19
 short_date: "0519"
+day_number: "139"
 this_date: May 19
 next_url: /westminster-daily/05/20
 next_date: May 20

--- a/content/05/20.md
+++ b/content/05/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/19
 prev_date: May 19
 this_url: /westminster-daily/05/20
 short_date: "0520"
+day_number: "140"
 this_date: May 20
 next_url: /westminster-daily/05/21
 next_date: May 21

--- a/content/05/21.md
+++ b/content/05/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/20
 prev_date: May 20
 this_url: /westminster-daily/05/21
 short_date: "0521"
+day_number: "141"
 this_date: May 21
 next_url: /westminster-daily/05/22
 next_date: May 22

--- a/content/05/22.md
+++ b/content/05/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/21
 prev_date: May 21
 this_url: /westminster-daily/05/22
 short_date: "0522"
+day_number: "142"
 this_date: May 22
 next_url: /westminster-daily/05/23
 next_date: May 23

--- a/content/05/23.md
+++ b/content/05/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/22
 prev_date: May 22
 this_url: /westminster-daily/05/23
 short_date: "0523"
+day_number: "143"
 this_date: May 23
 next_url: /westminster-daily/05/24
 next_date: May 24

--- a/content/05/24.md
+++ b/content/05/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/23
 prev_date: May 23
 this_url: /westminster-daily/05/24
 short_date: "0524"
+day_number: "144"
 this_date: May 24
 next_url: /westminster-daily/05/25
 next_date: May 25

--- a/content/05/25.md
+++ b/content/05/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/24
 prev_date: May 24
 this_url: /westminster-daily/05/25
 short_date: "0525"
+day_number: "145"
 this_date: May 25
 next_url: /westminster-daily/05/26
 next_date: May 26

--- a/content/05/26.md
+++ b/content/05/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/25
 prev_date: May 25
 this_url: /westminster-daily/05/26
 short_date: "0526"
+day_number: "146"
 this_date: May 26
 next_url: /westminster-daily/05/27
 next_date: May 27

--- a/content/05/27.md
+++ b/content/05/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/26
 prev_date: May 26
 this_url: /westminster-daily/05/27
 short_date: "0527"
+day_number: "147"
 this_date: May 27
 next_url: /westminster-daily/05/28
 next_date: May 28

--- a/content/05/28.md
+++ b/content/05/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/27
 prev_date: May 27
 this_url: /westminster-daily/05/28
 short_date: "0528"
+day_number: "148"
 this_date: May 28
 next_url: /westminster-daily/05/29
 next_date: May 29

--- a/content/05/29.md
+++ b/content/05/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/28
 prev_date: May 28
 this_url: /westminster-daily/05/29
 short_date: "0529"
+day_number: "149"
 this_date: May 29
 next_url: /westminster-daily/05/30
 next_date: May 30

--- a/content/05/30.md
+++ b/content/05/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/29
 prev_date: May 29
 this_url: /westminster-daily/05/30
 short_date: "0530"
+day_number: "150"
 this_date: May 30
 next_url: /westminster-daily/05/31
 next_date: May 31

--- a/content/05/31.md
+++ b/content/05/31.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/30
 prev_date: May 30
 this_url: /westminster-daily/05/31
 short_date: "0531"
+day_number: "151"
 this_date: May 31
 next_url: /westminster-daily/06/01
 next_date: Jun 1

--- a/content/06/01.md
+++ b/content/06/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/05/31
 prev_date: May 31
 this_url: /westminster-daily/06/01
 short_date: "0601"
+day_number: "152"
 this_date: Jun 1
 next_url: /westminster-daily/06/02
 next_date: Jun 2

--- a/content/06/02.md
+++ b/content/06/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/01
 prev_date: Jun 1
 this_url: /westminster-daily/06/02
 short_date: "0602"
+day_number: "153"
 this_date: Jun 2
 next_url: /westminster-daily/06/03
 next_date: Jun 3

--- a/content/06/03.md
+++ b/content/06/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/02
 prev_date: Jun 2
 this_url: /westminster-daily/06/03
 short_date: "0603"
+day_number: "154"
 this_date: Jun 3
 next_url: /westminster-daily/06/04
 next_date: Jun 4

--- a/content/06/04.md
+++ b/content/06/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/03
 prev_date: Jun 3
 this_url: /westminster-daily/06/04
 short_date: "0604"
+day_number: "155"
 this_date: Jun 4
 next_url: /westminster-daily/06/05
 next_date: Jun 5

--- a/content/06/05.md
+++ b/content/06/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/04
 prev_date: Jun 4
 this_url: /westminster-daily/06/05
 short_date: "0605"
+day_number: "156"
 this_date: Jun 5
 next_url: /westminster-daily/06/06
 next_date: Jun 6

--- a/content/06/06.md
+++ b/content/06/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/05
 prev_date: Jun 5
 this_url: /westminster-daily/06/06
 short_date: "0606"
+day_number: "157"
 this_date: Jun 6
 next_url: /westminster-daily/06/07
 next_date: Jun 7

--- a/content/06/07.md
+++ b/content/06/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/06
 prev_date: Jun 6
 this_url: /westminster-daily/06/07
 short_date: "0607"
+day_number: "158"
 this_date: Jun 7
 next_url: /westminster-daily/06/08
 next_date: Jun 8

--- a/content/06/08.md
+++ b/content/06/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/07
 prev_date: Jun 7
 this_url: /westminster-daily/06/08
 short_date: "0608"
+day_number: "159"
 this_date: Jun 8
 next_url: /westminster-daily/06/09
 next_date: Jun 9

--- a/content/06/09.md
+++ b/content/06/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/08
 prev_date: Jun 8
 this_url: /westminster-daily/06/09
 short_date: "0609"
+day_number: "160"
 this_date: Jun 9
 next_url: /westminster-daily/06/10
 next_date: Jun 10

--- a/content/06/10.md
+++ b/content/06/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/09
 prev_date: Jun 9
 this_url: /westminster-daily/06/10
 short_date: "0610"
+day_number: "161"
 this_date: Jun 10
 next_url: /westminster-daily/06/11
 next_date: Jun 11

--- a/content/06/11.md
+++ b/content/06/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/10
 prev_date: Jun 10
 this_url: /westminster-daily/06/11
 short_date: "0611"
+day_number: "162"
 this_date: Jun 11
 next_url: /westminster-daily/06/12
 next_date: Jun 12

--- a/content/06/12.md
+++ b/content/06/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/11
 prev_date: Jun 11
 this_url: /westminster-daily/06/12
 short_date: "0612"
+day_number: "163"
 this_date: Jun 12
 next_url: /westminster-daily/06/13
 next_date: Jun 13

--- a/content/06/13.md
+++ b/content/06/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/12
 prev_date: Jun 12
 this_url: /westminster-daily/06/13
 short_date: "0613"
+day_number: "164"
 this_date: Jun 13
 next_url: /westminster-daily/06/14
 next_date: Jun 14

--- a/content/06/14.md
+++ b/content/06/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/13
 prev_date: Jun 13
 this_url: /westminster-daily/06/14
 short_date: "0614"
+day_number: "165"
 this_date: Jun 14
 next_url: /westminster-daily/06/15
 next_date: Jun 15

--- a/content/06/15.md
+++ b/content/06/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/14
 prev_date: Jun 14
 this_url: /westminster-daily/06/15
 short_date: "0615"
+day_number: "166"
 this_date: Jun 15
 next_url: /westminster-daily/06/16
 next_date: Jun 16

--- a/content/06/16.md
+++ b/content/06/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/15
 prev_date: Jun 15
 this_url: /westminster-daily/06/16
 short_date: "0616"
+day_number: "167"
 this_date: Jun 16
 next_url: /westminster-daily/06/17
 next_date: Jun 17

--- a/content/06/17.md
+++ b/content/06/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/16
 prev_date: Jun 16
 this_url: /westminster-daily/06/17
 short_date: "0617"
+day_number: "168"
 this_date: Jun 17
 next_url: /westminster-daily/06/18
 next_date: Jun 18

--- a/content/06/18.md
+++ b/content/06/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/17
 prev_date: Jun 17
 this_url: /westminster-daily/06/18
 short_date: "0618"
+day_number: "169"
 this_date: Jun 18
 next_url: /westminster-daily/06/19
 next_date: Jun 19

--- a/content/06/19.md
+++ b/content/06/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/18
 prev_date: Jun 18
 this_url: /westminster-daily/06/19
 short_date: "0619"
+day_number: "170"
 this_date: Jun 19
 next_url: /westminster-daily/06/20
 next_date: Jun 20

--- a/content/06/20.md
+++ b/content/06/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/19
 prev_date: Jun 19
 this_url: /westminster-daily/06/20
 short_date: "0620"
+day_number: "171"
 this_date: Jun 20
 next_url: /westminster-daily/06/21
 next_date: Jun 21

--- a/content/06/21.md
+++ b/content/06/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/20
 prev_date: Jun 20
 this_url: /westminster-daily/06/21
 short_date: "0621"
+day_number: "172"
 this_date: Jun 21
 next_url: /westminster-daily/06/22
 next_date: Jun 22

--- a/content/06/22.md
+++ b/content/06/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/21
 prev_date: Jun 21
 this_url: /westminster-daily/06/22
 short_date: "0622"
+day_number: "173"
 this_date: Jun 22
 next_url: /westminster-daily/06/23
 next_date: Jun 23

--- a/content/06/23.md
+++ b/content/06/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/22
 prev_date: Jun 22
 this_url: /westminster-daily/06/23
 short_date: "0623"
+day_number: "174"
 this_date: Jun 23
 next_url: /westminster-daily/06/24
 next_date: Jun 24

--- a/content/06/24.md
+++ b/content/06/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/23
 prev_date: Jun 23
 this_url: /westminster-daily/06/24
 short_date: "0624"
+day_number: "175"
 this_date: Jun 24
 next_url: /westminster-daily/06/25
 next_date: Jun 25

--- a/content/06/25.md
+++ b/content/06/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/24
 prev_date: Jun 24
 this_url: /westminster-daily/06/25
 short_date: "0625"
+day_number: "176"
 this_date: Jun 25
 next_url: /westminster-daily/06/26
 next_date: Jun 26

--- a/content/06/26.md
+++ b/content/06/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/25
 prev_date: Jun 25
 this_url: /westminster-daily/06/26
 short_date: "0626"
+day_number: "177"
 this_date: Jun 26
 next_url: /westminster-daily/06/27
 next_date: Jun 27

--- a/content/06/27.md
+++ b/content/06/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/26
 prev_date: Jun 26
 this_url: /westminster-daily/06/27
 short_date: "0627"
+day_number: "178"
 this_date: Jun 27
 next_url: /westminster-daily/06/28
 next_date: Jun 28

--- a/content/06/28.md
+++ b/content/06/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/27
 prev_date: Jun 27
 this_url: /westminster-daily/06/28
 short_date: "0628"
+day_number: "179"
 this_date: Jun 28
 next_url: /westminster-daily/06/29
 next_date: Jun 29

--- a/content/06/29.md
+++ b/content/06/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/28
 prev_date: Jun 28
 this_url: /westminster-daily/06/29
 short_date: "0629"
+day_number: "180"
 this_date: Jun 29
 next_url: /westminster-daily/06/30
 next_date: Jun 30

--- a/content/06/30.md
+++ b/content/06/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/29
 prev_date: Jun 29
 this_url: /westminster-daily/06/30
 short_date: "0630"
+day_number: "181"
 this_date: Jun 30
 next_url: /westminster-daily/07/01
 next_date: Jul 1

--- a/content/07/01.md
+++ b/content/07/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/06/30
 prev_date: Jun 30
 this_url: /westminster-daily/07/01
 short_date: "0701"
+day_number: "182"
 this_date: Jul 1
 next_url: /westminster-daily/07/02
 next_date: Jul 2

--- a/content/07/02.md
+++ b/content/07/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/01
 prev_date: Jul 1
 this_url: /westminster-daily/07/02
 short_date: "0702"
+day_number: "183"
 this_date: Jul 2
 next_url: /westminster-daily/07/03
 next_date: Jul 3

--- a/content/07/03.md
+++ b/content/07/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/02
 prev_date: Jul 2
 this_url: /westminster-daily/07/03
 short_date: "0703"
+day_number: "184"
 this_date: Jul 3
 next_url: /westminster-daily/07/04
 next_date: Jul 4

--- a/content/07/04.md
+++ b/content/07/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/03
 prev_date: Jul 3
 this_url: /westminster-daily/07/04
 short_date: "0704"
+day_number: "185"
 this_date: Jul 4
 next_url: /westminster-daily/07/05
 next_date: Jul 5

--- a/content/07/05.md
+++ b/content/07/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/04
 prev_date: Jul 4
 this_url: /westminster-daily/07/05
 short_date: "0705"
+day_number: "186"
 this_date: Jul 5
 next_url: /westminster-daily/07/06
 next_date: Jul 6

--- a/content/07/06.md
+++ b/content/07/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/05
 prev_date: Jul 5
 this_url: /westminster-daily/07/06
 short_date: "0706"
+day_number: "187"
 this_date: Jul 6
 next_url: /westminster-daily/07/07
 next_date: Jul 7

--- a/content/07/07.md
+++ b/content/07/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/06
 prev_date: Jul 6
 this_url: /westminster-daily/07/07
 short_date: "0707"
+day_number: "188"
 this_date: Jul 7
 next_url: /westminster-daily/07/08
 next_date: Jul 8

--- a/content/07/08.md
+++ b/content/07/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/07
 prev_date: Jul 7
 this_url: /westminster-daily/07/08
 short_date: "0708"
+day_number: "189"
 this_date: Jul 8
 next_url: /westminster-daily/07/09
 next_date: Jul 9

--- a/content/07/09.md
+++ b/content/07/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/08
 prev_date: Jul 8
 this_url: /westminster-daily/07/09
 short_date: "0709"
+day_number: "190"
 this_date: Jul 9
 next_url: /westminster-daily/07/10
 next_date: Jul 10

--- a/content/07/10.md
+++ b/content/07/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/09
 prev_date: Jul 9
 this_url: /westminster-daily/07/10
 short_date: "0710"
+day_number: "191"
 this_date: Jul 10
 next_url: /westminster-daily/07/11
 next_date: Jul 11

--- a/content/07/11.md
+++ b/content/07/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/10
 prev_date: Jul 10
 this_url: /westminster-daily/07/11
 short_date: "0711"
+day_number: "192"
 this_date: Jul 11
 next_url: /westminster-daily/07/12
 next_date: Jul 12

--- a/content/07/12.md
+++ b/content/07/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/11
 prev_date: Jul 11
 this_url: /westminster-daily/07/12
 short_date: "0712"
+day_number: "193"
 this_date: Jul 12
 next_url: /westminster-daily/07/13
 next_date: Jul 13

--- a/content/07/13.md
+++ b/content/07/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/12
 prev_date: Jul 12
 this_url: /westminster-daily/07/13
 short_date: "0713"
+day_number: "194"
 this_date: Jul 13
 next_url: /westminster-daily/07/14
 next_date: Jul 14

--- a/content/07/14.md
+++ b/content/07/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/13
 prev_date: Jul 13
 this_url: /westminster-daily/07/14
 short_date: "0714"
+day_number: "195"
 this_date: Jul 14
 next_url: /westminster-daily/07/15
 next_date: Jul 15

--- a/content/07/15.md
+++ b/content/07/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/14
 prev_date: Jul 14
 this_url: /westminster-daily/07/15
 short_date: "0715"
+day_number: "196"
 this_date: Jul 15
 next_url: /westminster-daily/07/16
 next_date: Jul 16

--- a/content/07/16.md
+++ b/content/07/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/15
 prev_date: Jul 15
 this_url: /westminster-daily/07/16
 short_date: "0716"
+day_number: "197"
 this_date: Jul 16
 next_url: /westminster-daily/07/17
 next_date: Jul 17

--- a/content/07/17.md
+++ b/content/07/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/16
 prev_date: Jul 16
 this_url: /westminster-daily/07/17
 short_date: "0717"
+day_number: "198"
 this_date: Jul 17
 next_url: /westminster-daily/07/18
 next_date: Jul 18

--- a/content/07/18.md
+++ b/content/07/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/17
 prev_date: Jul 17
 this_url: /westminster-daily/07/18
 short_date: "0718"
+day_number: "199"
 this_date: Jul 18
 next_url: /westminster-daily/07/19
 next_date: Jul 19

--- a/content/07/19.md
+++ b/content/07/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/18
 prev_date: Jul 18
 this_url: /westminster-daily/07/19
 short_date: "0719"
+day_number: "200"
 this_date: Jul 19
 next_url: /westminster-daily/07/20
 next_date: Jul 20

--- a/content/07/20.md
+++ b/content/07/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/19
 prev_date: Jul 19
 this_url: /westminster-daily/07/20
 short_date: "0720"
+day_number: "201"
 this_date: Jul 20
 next_url: /westminster-daily/07/21
 next_date: Jul 21

--- a/content/07/21.md
+++ b/content/07/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/20
 prev_date: Jul 20
 this_url: /westminster-daily/07/21
 short_date: "0721"
+day_number: "202"
 this_date: Jul 21
 next_url: /westminster-daily/07/22
 next_date: Jul 22

--- a/content/07/22.md
+++ b/content/07/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/21
 prev_date: Jul 21
 this_url: /westminster-daily/07/22
 short_date: "0722"
+day_number: "203"
 this_date: Jul 22
 next_url: /westminster-daily/07/23
 next_date: Jul 23

--- a/content/07/23.md
+++ b/content/07/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/22
 prev_date: Jul 22
 this_url: /westminster-daily/07/23
 short_date: "0723"
+day_number: "204"
 this_date: Jul 23
 next_url: /westminster-daily/07/24
 next_date: Jul 24

--- a/content/07/24.md
+++ b/content/07/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/23
 prev_date: Jul 23
 this_url: /westminster-daily/07/24
 short_date: "0724"
+day_number: "205"
 this_date: Jul 24
 next_url: /westminster-daily/07/25
 next_date: Jul 25

--- a/content/07/25.md
+++ b/content/07/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/24
 prev_date: Jul 24
 this_url: /westminster-daily/07/25
 short_date: "0725"
+day_number: "206"
 this_date: Jul 25
 next_url: /westminster-daily/07/26
 next_date: Jul 26

--- a/content/07/26.md
+++ b/content/07/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/25
 prev_date: Jul 25
 this_url: /westminster-daily/07/26
 short_date: "0726"
+day_number: "207"
 this_date: Jul 26
 next_url: /westminster-daily/07/27
 next_date: Jul 27

--- a/content/07/27.md
+++ b/content/07/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/26
 prev_date: Jul 26
 this_url: /westminster-daily/07/27
 short_date: "0727"
+day_number: "208"
 this_date: Jul 27
 next_url: /westminster-daily/07/28
 next_date: Jul 28

--- a/content/07/28.md
+++ b/content/07/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/27
 prev_date: Jul 27
 this_url: /westminster-daily/07/28
 short_date: "0728"
+day_number: "209"
 this_date: Jul 28
 next_url: /westminster-daily/07/29
 next_date: Jul 29

--- a/content/07/29.md
+++ b/content/07/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/28
 prev_date: Jul 28
 this_url: /westminster-daily/07/29
 short_date: "0729"
+day_number: "210"
 this_date: Jul 29
 next_url: /westminster-daily/07/30
 next_date: Jul 30

--- a/content/07/30.md
+++ b/content/07/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/29
 prev_date: Jul 29
 this_url: /westminster-daily/07/30
 short_date: "0730"
+day_number: "211"
 this_date: Jul 30
 next_url: /westminster-daily/07/31
 next_date: Jul 31

--- a/content/07/31.md
+++ b/content/07/31.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/30
 prev_date: Jul 30
 this_url: /westminster-daily/07/31
 short_date: "0731"
+day_number: "212"
 this_date: Jul 31
 next_url: /westminster-daily/08/01
 next_date: Aug 1

--- a/content/08/01.md
+++ b/content/08/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/07/31
 prev_date: Jul 31
 this_url: /westminster-daily/08/01
 short_date: "0801"
+day_number: "213"
 this_date: Aug 1
 next_url: /westminster-daily/08/02
 next_date: Aug 2

--- a/content/08/02.md
+++ b/content/08/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/01
 prev_date: Aug 1
 this_url: /westminster-daily/08/02
 short_date: "0802"
+day_number: "214"
 this_date: Aug 2
 next_url: /westminster-daily/08/03
 next_date: Aug 3

--- a/content/08/03.md
+++ b/content/08/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/02
 prev_date: Aug 2
 this_url: /westminster-daily/08/03
 short_date: "0803"
+day_number: "215"
 this_date: Aug 3
 next_url: /westminster-daily/08/04
 next_date: Aug 4

--- a/content/08/04.md
+++ b/content/08/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/03
 prev_date: Aug 3
 this_url: /westminster-daily/08/04
 short_date: "0804"
+day_number: "216"
 this_date: Aug 4
 next_url: /westminster-daily/08/05
 next_date: Aug 5

--- a/content/08/05.md
+++ b/content/08/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/04
 prev_date: Aug 4
 this_url: /westminster-daily/08/05
 short_date: "0805"
+day_number: "217"
 this_date: Aug 5
 next_url: /westminster-daily/08/06
 next_date: Aug 6

--- a/content/08/06.md
+++ b/content/08/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/05
 prev_date: Aug 5
 this_url: /westminster-daily/08/06
 short_date: "0806"
+day_number: "218"
 this_date: Aug 6
 next_url: /westminster-daily/08/07
 next_date: Aug 7

--- a/content/08/07.md
+++ b/content/08/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/06
 prev_date: Aug 6
 this_url: /westminster-daily/08/07
 short_date: "0807"
+day_number: "219"
 this_date: Aug 7
 next_url: /westminster-daily/08/08
 next_date: Aug 8

--- a/content/08/08.md
+++ b/content/08/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/07
 prev_date: Aug 7
 this_url: /westminster-daily/08/08
 short_date: "0808"
+day_number: "220"
 this_date: Aug 8
 next_url: /westminster-daily/08/09
 next_date: Aug 9

--- a/content/08/09.md
+++ b/content/08/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/08
 prev_date: Aug 8
 this_url: /westminster-daily/08/09
 short_date: "0809"
+day_number: "221"
 this_date: Aug 9
 next_url: /westminster-daily/08/10
 next_date: Aug 10

--- a/content/08/10.md
+++ b/content/08/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/09
 prev_date: Aug 9
 this_url: /westminster-daily/08/10
 short_date: "0810"
+day_number: "222"
 this_date: Aug 10
 next_url: /westminster-daily/08/11
 next_date: Aug 11

--- a/content/08/11.md
+++ b/content/08/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/10
 prev_date: Aug 10
 this_url: /westminster-daily/08/11
 short_date: "0811"
+day_number: "223"
 this_date: Aug 11
 next_url: /westminster-daily/08/12
 next_date: Aug 12

--- a/content/08/12.md
+++ b/content/08/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/11
 prev_date: Aug 11
 this_url: /westminster-daily/08/12
 short_date: "0812"
+day_number: "224"
 this_date: Aug 12
 next_url: /westminster-daily/08/13
 next_date: Aug 13

--- a/content/08/13.md
+++ b/content/08/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/12
 prev_date: Aug 12
 this_url: /westminster-daily/08/13
 short_date: "0813"
+day_number: "225"
 this_date: Aug 13
 next_url: /westminster-daily/08/14
 next_date: Aug 14

--- a/content/08/14.md
+++ b/content/08/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/13
 prev_date: Aug 13
 this_url: /westminster-daily/08/14
 short_date: "0814"
+day_number: "226"
 this_date: Aug 14
 next_url: /westminster-daily/08/15
 next_date: Aug 15

--- a/content/08/15.md
+++ b/content/08/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/14
 prev_date: Aug 14
 this_url: /westminster-daily/08/15
 short_date: "0815"
+day_number: "227"
 this_date: Aug 15
 next_url: /westminster-daily/08/16
 next_date: Aug 16

--- a/content/08/16.md
+++ b/content/08/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/15
 prev_date: Aug 15
 this_url: /westminster-daily/08/16
 short_date: "0816"
+day_number: "228"
 this_date: Aug 16
 next_url: /westminster-daily/08/17
 next_date: Aug 17

--- a/content/08/17.md
+++ b/content/08/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/16
 prev_date: Aug 16
 this_url: /westminster-daily/08/17
 short_date: "0817"
+day_number: "229"
 this_date: Aug 17
 next_url: /westminster-daily/08/18
 next_date: Aug 18

--- a/content/08/18.md
+++ b/content/08/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/17
 prev_date: Aug 17
 this_url: /westminster-daily/08/18
 short_date: "0818"
+day_number: "230"
 this_date: Aug 18
 next_url: /westminster-daily/08/19
 next_date: Aug 19

--- a/content/08/19.md
+++ b/content/08/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/18
 prev_date: Aug 18
 this_url: /westminster-daily/08/19
 short_date: "0819"
+day_number: "231"
 this_date: Aug 19
 next_url: /westminster-daily/08/20
 next_date: Aug 20

--- a/content/08/20.md
+++ b/content/08/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/19
 prev_date: Aug 19
 this_url: /westminster-daily/08/20
 short_date: "0820"
+day_number: "232"
 this_date: Aug 20
 next_url: /westminster-daily/08/21
 next_date: Aug 21

--- a/content/08/21.md
+++ b/content/08/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/20
 prev_date: Aug 20
 this_url: /westminster-daily/08/21
 short_date: "0821"
+day_number: "233"
 this_date: Aug 21
 next_url: /westminster-daily/08/22
 next_date: Aug 22

--- a/content/08/22.md
+++ b/content/08/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/21
 prev_date: Aug 21
 this_url: /westminster-daily/08/22
 short_date: "0822"
+day_number: "234"
 this_date: Aug 22
 next_url: /westminster-daily/08/23
 next_date: Aug 23

--- a/content/08/23.md
+++ b/content/08/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/22
 prev_date: Aug 22
 this_url: /westminster-daily/08/23
 short_date: "0823"
+day_number: "235"
 this_date: Aug 23
 next_url: /westminster-daily/08/24
 next_date: Aug 24

--- a/content/08/24.md
+++ b/content/08/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/23
 prev_date: Aug 23
 this_url: /westminster-daily/08/24
 short_date: "0824"
+day_number: "236"
 this_date: Aug 24
 next_url: /westminster-daily/08/25
 next_date: Aug 25

--- a/content/08/25.md
+++ b/content/08/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/24
 prev_date: Aug 24
 this_url: /westminster-daily/08/25
 short_date: "0825"
+day_number: "237"
 this_date: Aug 25
 next_url: /westminster-daily/08/26
 next_date: Aug 26

--- a/content/08/26.md
+++ b/content/08/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/25
 prev_date: Aug 25
 this_url: /westminster-daily/08/26
 short_date: "0826"
+day_number: "238"
 this_date: Aug 26
 next_url: /westminster-daily/08/27
 next_date: Aug 27

--- a/content/08/27.md
+++ b/content/08/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/26
 prev_date: Aug 26
 this_url: /westminster-daily/08/27
 short_date: "0827"
+day_number: "239"
 this_date: Aug 27
 next_url: /westminster-daily/08/28
 next_date: Aug 28

--- a/content/08/28.md
+++ b/content/08/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/27
 prev_date: Aug 27
 this_url: /westminster-daily/08/28
 short_date: "0828"
+day_number: "240"
 this_date: Aug 28
 next_url: /westminster-daily/08/29
 next_date: Aug 29

--- a/content/08/29.md
+++ b/content/08/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/28
 prev_date: Aug 28
 this_url: /westminster-daily/08/29
 short_date: "0829"
+day_number: "241"
 this_date: Aug 29
 next_url: /westminster-daily/08/30
 next_date: Aug 30

--- a/content/08/30.md
+++ b/content/08/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/29
 prev_date: Aug 29
 this_url: /westminster-daily/08/30
 short_date: "0830"
+day_number: "242"
 this_date: Aug 30
 next_url: /westminster-daily/08/31
 next_date: Aug 31

--- a/content/08/31.md
+++ b/content/08/31.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/30
 prev_date: Aug 30
 this_url: /westminster-daily/08/31
 short_date: "0831"
+day_number: "243"
 this_date: Aug 31
 next_url: /westminster-daily/09/01
 next_date: Sep 1

--- a/content/09/01.md
+++ b/content/09/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/08/31
 prev_date: Aug 31
 this_url: /westminster-daily/09/01
 short_date: "0901"
+day_number: "244"
 this_date: Sep 1
 next_url: /westminster-daily/09/02
 next_date: Sep 2

--- a/content/09/02.md
+++ b/content/09/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/01
 prev_date: Sep 1
 this_url: /westminster-daily/09/02
 short_date: "0902"
+day_number: "245"
 this_date: Sep 2
 next_url: /westminster-daily/09/03
 next_date: Sep 3

--- a/content/09/03.md
+++ b/content/09/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/02
 prev_date: Sep 2
 this_url: /westminster-daily/09/03
 short_date: "0903"
+day_number: "246"
 this_date: Sep 3
 next_url: /westminster-daily/09/04
 next_date: Sep 4

--- a/content/09/04.md
+++ b/content/09/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/03
 prev_date: Sep 3
 this_url: /westminster-daily/09/04
 short_date: "0904"
+day_number: "247"
 this_date: Sep 4
 next_url: /westminster-daily/09/05
 next_date: Sep 5

--- a/content/09/05.md
+++ b/content/09/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/04
 prev_date: Sep 4
 this_url: /westminster-daily/09/05
 short_date: "0905"
+day_number: "248"
 this_date: Sep 5
 next_url: /westminster-daily/09/06
 next_date: Sep 6

--- a/content/09/06.md
+++ b/content/09/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/05
 prev_date: Sep 5
 this_url: /westminster-daily/09/06
 short_date: "0906"
+day_number: "249"
 this_date: Sep 6
 next_url: /westminster-daily/09/07
 next_date: Sep 7

--- a/content/09/07.md
+++ b/content/09/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/06
 prev_date: Sep 6
 this_url: /westminster-daily/09/07
 short_date: "0907"
+day_number: "250"
 this_date: Sep 7
 next_url: /westminster-daily/09/08
 next_date: Sep 8

--- a/content/09/08.md
+++ b/content/09/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/07
 prev_date: Sep 7
 this_url: /westminster-daily/09/08
 short_date: "0908"
+day_number: "251"
 this_date: Sep 8
 next_url: /westminster-daily/09/09
 next_date: Sep 9

--- a/content/09/09.md
+++ b/content/09/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/08
 prev_date: Sep 8
 this_url: /westminster-daily/09/09
 short_date: "0909"
+day_number: "252"
 this_date: Sep 9
 next_url: /westminster-daily/09/10
 next_date: Sep 10

--- a/content/09/10.md
+++ b/content/09/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/09
 prev_date: Sep 9
 this_url: /westminster-daily/09/10
 short_date: "0910"
+day_number: "253"
 this_date: Sep 10
 next_url: /westminster-daily/09/11
 next_date: Sep 11

--- a/content/09/11.md
+++ b/content/09/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/10
 prev_date: Sep 10
 this_url: /westminster-daily/09/11
 short_date: "0911"
+day_number: "254"
 this_date: Sep 11
 next_url: /westminster-daily/09/12
 next_date: Sep 12

--- a/content/09/12.md
+++ b/content/09/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/11
 prev_date: Sep 11
 this_url: /westminster-daily/09/12
 short_date: "0912"
+day_number: "255"
 this_date: Sep 12
 next_url: /westminster-daily/09/13
 next_date: Sep 13

--- a/content/09/13.md
+++ b/content/09/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/12
 prev_date: Sep 12
 this_url: /westminster-daily/09/13
 short_date: "0913"
+day_number: "256"
 this_date: Sep 13
 next_url: /westminster-daily/09/14
 next_date: Sep 14

--- a/content/09/14.md
+++ b/content/09/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/13
 prev_date: Sep 13
 this_url: /westminster-daily/09/14
 short_date: "0914"
+day_number: "257"
 this_date: Sep 14
 next_url: /westminster-daily/09/15
 next_date: Sep 15

--- a/content/09/15.md
+++ b/content/09/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/14
 prev_date: Sep 14
 this_url: /westminster-daily/09/15
 short_date: "0915"
+day_number: "258"
 this_date: Sep 15
 next_url: /westminster-daily/09/16
 next_date: Sep 16

--- a/content/09/16.md
+++ b/content/09/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/15
 prev_date: Sep 15
 this_url: /westminster-daily/09/16
 short_date: "0916"
+day_number: "259"
 this_date: Sep 16
 next_url: /westminster-daily/09/17
 next_date: Sep 17

--- a/content/09/17.md
+++ b/content/09/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/16
 prev_date: Sep 16
 this_url: /westminster-daily/09/17
 short_date: "0917"
+day_number: "260"
 this_date: Sep 17
 next_url: /westminster-daily/09/18
 next_date: Sep 18

--- a/content/09/18.md
+++ b/content/09/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/17
 prev_date: Sep 17
 this_url: /westminster-daily/09/18
 short_date: "0918"
+day_number: "261"
 this_date: Sep 18
 next_url: /westminster-daily/09/19
 next_date: Sep 19

--- a/content/09/19.md
+++ b/content/09/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/18
 prev_date: Sep 18
 this_url: /westminster-daily/09/19
 short_date: "0919"
+day_number: "262"
 this_date: Sep 19
 next_url: /westminster-daily/09/20
 next_date: Sep 20

--- a/content/09/20.md
+++ b/content/09/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/19
 prev_date: Sep 19
 this_url: /westminster-daily/09/20
 short_date: "0920"
+day_number: "263"
 this_date: Sep 20
 next_url: /westminster-daily/09/21
 next_date: Sep 21

--- a/content/09/21.md
+++ b/content/09/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/20
 prev_date: Sep 20
 this_url: /westminster-daily/09/21
 short_date: "0921"
+day_number: "264"
 this_date: Sep 21
 next_url: /westminster-daily/09/22
 next_date: Sep 22

--- a/content/09/22.md
+++ b/content/09/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/21
 prev_date: Sep 21
 this_url: /westminster-daily/09/22
 short_date: "0922"
+day_number: "265"
 this_date: Sep 22
 next_url: /westminster-daily/09/23
 next_date: Sep 23

--- a/content/09/23.md
+++ b/content/09/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/22
 prev_date: Sep 22
 this_url: /westminster-daily/09/23
 short_date: "0923"
+day_number: "266"
 this_date: Sep 23
 next_url: /westminster-daily/09/24
 next_date: Sep 24

--- a/content/09/24.md
+++ b/content/09/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/23
 prev_date: Sep 23
 this_url: /westminster-daily/09/24
 short_date: "0924"
+day_number: "267"
 this_date: Sep 24
 next_url: /westminster-daily/09/25
 next_date: Sep 25

--- a/content/09/25.md
+++ b/content/09/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/24
 prev_date: Sep 24
 this_url: /westminster-daily/09/25
 short_date: "0925"
+day_number: "268"
 this_date: Sep 25
 next_url: /westminster-daily/09/26
 next_date: Sep 26

--- a/content/09/26.md
+++ b/content/09/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/25
 prev_date: Sep 25
 this_url: /westminster-daily/09/26
 short_date: "0926"
+day_number: "269"
 this_date: Sep 26
 next_url: /westminster-daily/09/27
 next_date: Sep 27

--- a/content/09/27.md
+++ b/content/09/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/26
 prev_date: Sep 26
 this_url: /westminster-daily/09/27
 short_date: "0927"
+day_number: "270"
 this_date: Sep 27
 next_url: /westminster-daily/09/28
 next_date: Sep 28

--- a/content/09/28.md
+++ b/content/09/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/27
 prev_date: Sep 27
 this_url: /westminster-daily/09/28
 short_date: "0928"
+day_number: "271"
 this_date: Sep 28
 next_url: /westminster-daily/09/29
 next_date: Sep 29

--- a/content/09/29.md
+++ b/content/09/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/28
 prev_date: Sep 28
 this_url: /westminster-daily/09/29
 short_date: "0929"
+day_number: "272"
 this_date: Sep 29
 next_url: /westminster-daily/09/30
 next_date: Sep 30

--- a/content/09/30.md
+++ b/content/09/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/29
 prev_date: Sep 29
 this_url: /westminster-daily/09/30
 short_date: "0930"
+day_number: "273"
 this_date: Sep 30
 next_url: /westminster-daily/10/01
 next_date: Oct 1

--- a/content/10/01.md
+++ b/content/10/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/09/30
 prev_date: Sep 30
 this_url: /westminster-daily/10/01
 short_date: "1001"
+day_number: "274"
 this_date: Oct 1
 next_url: /westminster-daily/10/02
 next_date: Oct 2

--- a/content/10/02.md
+++ b/content/10/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/01
 prev_date: Oct 1
 this_url: /westminster-daily/10/02
 short_date: "1002"
+day_number: "275"
 this_date: Oct 2
 next_url: /westminster-daily/10/03
 next_date: Oct 3

--- a/content/10/03.md
+++ b/content/10/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/02
 prev_date: Oct 2
 this_url: /westminster-daily/10/03
 short_date: "1003"
+day_number: "276"
 this_date: Oct 3
 next_url: /westminster-daily/10/04
 next_date: Oct 4

--- a/content/10/04.md
+++ b/content/10/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/03
 prev_date: Oct 3
 this_url: /westminster-daily/10/04
 short_date: "1004"
+day_number: "277"
 this_date: Oct 4
 next_url: /westminster-daily/10/05
 next_date: Oct 5

--- a/content/10/05.md
+++ b/content/10/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/04
 prev_date: Oct 4
 this_url: /westminster-daily/10/05
 short_date: "1005"
+day_number: "278"
 this_date: Oct 5
 next_url: /westminster-daily/10/06
 next_date: Oct 6

--- a/content/10/06.md
+++ b/content/10/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/05
 prev_date: Oct 5
 this_url: /westminster-daily/10/06
 short_date: "1006"
+day_number: "279"
 this_date: Oct 6
 next_url: /westminster-daily/10/07
 next_date: Oct 7

--- a/content/10/07.md
+++ b/content/10/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/06
 prev_date: Oct 6
 this_url: /westminster-daily/10/07
 short_date: "1007"
+day_number: "280"
 this_date: Oct 7
 next_url: /westminster-daily/10/08
 next_date: Oct 8

--- a/content/10/08.md
+++ b/content/10/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/07
 prev_date: Oct 7
 this_url: /westminster-daily/10/08
 short_date: "1008"
+day_number: "281"
 this_date: Oct 8
 next_url: /westminster-daily/10/09
 next_date: Oct 9

--- a/content/10/09.md
+++ b/content/10/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/08
 prev_date: Oct 8
 this_url: /westminster-daily/10/09
 short_date: "1009"
+day_number: "282"
 this_date: Oct 9
 next_url: /westminster-daily/10/10
 next_date: Oct 10

--- a/content/10/10.md
+++ b/content/10/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/09
 prev_date: Oct 9
 this_url: /westminster-daily/10/10
 short_date: "1010"
+day_number: "283"
 this_date: Oct 10
 next_url: /westminster-daily/10/11
 next_date: Oct 11

--- a/content/10/11.md
+++ b/content/10/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/10
 prev_date: Oct 10
 this_url: /westminster-daily/10/11
 short_date: "1011"
+day_number: "284"
 this_date: Oct 11
 next_url: /westminster-daily/10/12
 next_date: Oct 12

--- a/content/10/12.md
+++ b/content/10/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/11
 prev_date: Oct 11
 this_url: /westminster-daily/10/12
 short_date: "1012"
+day_number: "285"
 this_date: Oct 12
 next_url: /westminster-daily/10/13
 next_date: Oct 13

--- a/content/10/13.md
+++ b/content/10/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/12
 prev_date: Oct 12
 this_url: /westminster-daily/10/13
 short_date: "1013"
+day_number: "286"
 this_date: Oct 13
 next_url: /westminster-daily/10/14
 next_date: Oct 14

--- a/content/10/14.md
+++ b/content/10/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/13
 prev_date: Oct 13
 this_url: /westminster-daily/10/14
 short_date: "1014"
+day_number: "287"
 this_date: Oct 14
 next_url: /westminster-daily/10/15
 next_date: Oct 15

--- a/content/10/15.md
+++ b/content/10/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/14
 prev_date: Oct 14
 this_url: /westminster-daily/10/15
 short_date: "1015"
+day_number: "288"
 this_date: Oct 15
 next_url: /westminster-daily/10/16
 next_date: Oct 16

--- a/content/10/16.md
+++ b/content/10/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/15
 prev_date: Oct 15
 this_url: /westminster-daily/10/16
 short_date: "1016"
+day_number: "289"
 this_date: Oct 16
 next_url: /westminster-daily/10/17
 next_date: Oct 17

--- a/content/10/17.md
+++ b/content/10/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/16
 prev_date: Oct 16
 this_url: /westminster-daily/10/17
 short_date: "1017"
+day_number: "290"
 this_date: Oct 17
 next_url: /westminster-daily/10/18
 next_date: Oct 18

--- a/content/10/18.md
+++ b/content/10/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/17
 prev_date: Oct 17
 this_url: /westminster-daily/10/18
 short_date: "1018"
+day_number: "291"
 this_date: Oct 18
 next_url: /westminster-daily/10/19
 next_date: Oct 19

--- a/content/10/19.md
+++ b/content/10/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/18
 prev_date: Oct 18
 this_url: /westminster-daily/10/19
 short_date: "1019"
+day_number: "292"
 this_date: Oct 19
 next_url: /westminster-daily/10/20
 next_date: Oct 20

--- a/content/10/20.md
+++ b/content/10/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/19
 prev_date: Oct 19
 this_url: /westminster-daily/10/20
 short_date: "1020"
+day_number: "293"
 this_date: Oct 20
 next_url: /westminster-daily/10/21
 next_date: Oct 21

--- a/content/10/21.md
+++ b/content/10/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/20
 prev_date: Oct 20
 this_url: /westminster-daily/10/21
 short_date: "1021"
+day_number: "294"
 this_date: Oct 21
 next_url: /westminster-daily/10/22
 next_date: Oct 22

--- a/content/10/22.md
+++ b/content/10/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/21
 prev_date: Oct 21
 this_url: /westminster-daily/10/22
 short_date: "1022"
+day_number: "295"
 this_date: Oct 22
 next_url: /westminster-daily/10/23
 next_date: Oct 23

--- a/content/10/23.md
+++ b/content/10/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/22
 prev_date: Oct 22
 this_url: /westminster-daily/10/23
 short_date: "1023"
+day_number: "296"
 this_date: Oct 23
 next_url: /westminster-daily/10/24
 next_date: Oct 24

--- a/content/10/24.md
+++ b/content/10/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/23
 prev_date: Oct 23
 this_url: /westminster-daily/10/24
 short_date: "1024"
+day_number: "297"
 this_date: Oct 24
 next_url: /westminster-daily/10/25
 next_date: Oct 25

--- a/content/10/25.md
+++ b/content/10/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/24
 prev_date: Oct 24
 this_url: /westminster-daily/10/25
 short_date: "1025"
+day_number: "298"
 this_date: Oct 25
 next_url: /westminster-daily/10/26
 next_date: Oct 26

--- a/content/10/26.md
+++ b/content/10/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/25
 prev_date: Oct 25
 this_url: /westminster-daily/10/26
 short_date: "1026"
+day_number: "299"
 this_date: Oct 26
 next_url: /westminster-daily/10/27
 next_date: Oct 27

--- a/content/10/27.md
+++ b/content/10/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/26
 prev_date: Oct 26
 this_url: /westminster-daily/10/27
 short_date: "1027"
+day_number: "300"
 this_date: Oct 27
 next_url: /westminster-daily/10/28
 next_date: Oct 28

--- a/content/10/28.md
+++ b/content/10/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/27
 prev_date: Oct 27
 this_url: /westminster-daily/10/28
 short_date: "1028"
+day_number: "301"
 this_date: Oct 28
 next_url: /westminster-daily/10/29
 next_date: Oct 29

--- a/content/10/29.md
+++ b/content/10/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/28
 prev_date: Oct 28
 this_url: /westminster-daily/10/29
 short_date: "1029"
+day_number: "302"
 this_date: Oct 29
 next_url: /westminster-daily/10/30
 next_date: Oct 30

--- a/content/10/30.md
+++ b/content/10/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/29
 prev_date: Oct 29
 this_url: /westminster-daily/10/30
 short_date: "1030"
+day_number: "303"
 this_date: Oct 30
 next_url: /westminster-daily/10/31
 next_date: Oct 31

--- a/content/10/31.md
+++ b/content/10/31.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/30
 prev_date: Oct 30
 this_url: /westminster-daily/10/31
 short_date: "1031"
+day_number: "304"
 this_date: Oct 31
 next_url: /westminster-daily/11/01
 next_date: Nov 1

--- a/content/11/01.md
+++ b/content/11/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/10/31
 prev_date: Oct 31
 this_url: /westminster-daily/11/01
 short_date: "1101"
+day_number: "305"
 this_date: Nov 1
 next_url: /westminster-daily/11/02
 next_date: Nov 2

--- a/content/11/02.md
+++ b/content/11/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/01
 prev_date: Nov 1
 this_url: /westminster-daily/11/02
 short_date: "1102"
+day_number: "306"
 this_date: Nov 2
 next_url: /westminster-daily/11/03
 next_date: Nov 3

--- a/content/11/03.md
+++ b/content/11/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/02
 prev_date: Nov 2
 this_url: /westminster-daily/11/03
 short_date: "1103"
+day_number: "307"
 this_date: Nov 3
 next_url: /westminster-daily/11/04
 next_date: Nov 4

--- a/content/11/04.md
+++ b/content/11/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/03
 prev_date: Nov 3
 this_url: /westminster-daily/11/04
 short_date: "1104"
+day_number: "308"
 this_date: Nov 4
 next_url: /westminster-daily/11/05
 next_date: Nov 5

--- a/content/11/05.md
+++ b/content/11/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/04
 prev_date: Nov 4
 this_url: /westminster-daily/11/05
 short_date: "1105"
+day_number: "309"
 this_date: Nov 5
 next_url: /westminster-daily/11/06
 next_date: Nov 6

--- a/content/11/06.md
+++ b/content/11/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/05
 prev_date: Nov 5
 this_url: /westminster-daily/11/06
 short_date: "1106"
+day_number: "310"
 this_date: Nov 6
 next_url: /westminster-daily/11/07
 next_date: Nov 7

--- a/content/11/07.md
+++ b/content/11/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/06
 prev_date: Nov 6
 this_url: /westminster-daily/11/07
 short_date: "1107"
+day_number: "311"
 this_date: Nov 7
 next_url: /westminster-daily/11/08
 next_date: Nov 8

--- a/content/11/08.md
+++ b/content/11/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/07
 prev_date: Nov 7
 this_url: /westminster-daily/11/08
 short_date: "1108"
+day_number: "312"
 this_date: Nov 8
 next_url: /westminster-daily/11/09
 next_date: Nov 9

--- a/content/11/09.md
+++ b/content/11/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/08
 prev_date: Nov 8
 this_url: /westminster-daily/11/09
 short_date: "1109"
+day_number: "313"
 this_date: Nov 9
 next_url: /westminster-daily/11/10
 next_date: Nov 10

--- a/content/11/10.md
+++ b/content/11/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/09
 prev_date: Nov 9
 this_url: /westminster-daily/11/10
 short_date: "1110"
+day_number: "314"
 this_date: Nov 10
 next_url: /westminster-daily/11/11
 next_date: Nov 11

--- a/content/11/11.md
+++ b/content/11/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/10
 prev_date: Nov 10
 this_url: /westminster-daily/11/11
 short_date: "1111"
+day_number: "315"
 this_date: Nov 11
 next_url: /westminster-daily/11/12
 next_date: Nov 12

--- a/content/11/12.md
+++ b/content/11/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/11
 prev_date: Nov 11
 this_url: /westminster-daily/11/12
 short_date: "1112"
+day_number: "316"
 this_date: Nov 12
 next_url: /westminster-daily/11/13
 next_date: Nov 13

--- a/content/11/13.md
+++ b/content/11/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/12
 prev_date: Nov 12
 this_url: /westminster-daily/11/13
 short_date: "1113"
+day_number: "317"
 this_date: Nov 13
 next_url: /westminster-daily/11/14
 next_date: Nov 14

--- a/content/11/14.md
+++ b/content/11/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/13
 prev_date: Nov 13
 this_url: /westminster-daily/11/14
 short_date: "1114"
+day_number: "318"
 this_date: Nov 14
 next_url: /westminster-daily/11/15
 next_date: Nov 15

--- a/content/11/15.md
+++ b/content/11/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/14
 prev_date: Nov 14
 this_url: /westminster-daily/11/15
 short_date: "1115"
+day_number: "319"
 this_date: Nov 15
 next_url: /westminster-daily/11/16
 next_date: Nov 16

--- a/content/11/16.md
+++ b/content/11/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/15
 prev_date: Nov 15
 this_url: /westminster-daily/11/16
 short_date: "1116"
+day_number: "320"
 this_date: Nov 16
 next_url: /westminster-daily/11/17
 next_date: Nov 17

--- a/content/11/17.md
+++ b/content/11/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/16
 prev_date: Nov 16
 this_url: /westminster-daily/11/17
 short_date: "1117"
+day_number: "321"
 this_date: Nov 17
 next_url: /westminster-daily/11/18
 next_date: Nov 18

--- a/content/11/18.md
+++ b/content/11/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/17
 prev_date: Nov 17
 this_url: /westminster-daily/11/18
 short_date: "1118"
+day_number: "322"
 this_date: Nov 18
 next_url: /westminster-daily/11/19
 next_date: Nov 19

--- a/content/11/19.md
+++ b/content/11/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/18
 prev_date: Nov 18
 this_url: /westminster-daily/11/19
 short_date: "1119"
+day_number: "323"
 this_date: Nov 19
 next_url: /westminster-daily/11/20
 next_date: Nov 20

--- a/content/11/20.md
+++ b/content/11/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/19
 prev_date: Nov 19
 this_url: /westminster-daily/11/20
 short_date: "1120"
+day_number: "324"
 this_date: Nov 20
 next_url: /westminster-daily/11/21
 next_date: Nov 21

--- a/content/11/21.md
+++ b/content/11/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/20
 prev_date: Nov 20
 this_url: /westminster-daily/11/21
 short_date: "1121"
+day_number: "325"
 this_date: Nov 21
 next_url: /westminster-daily/11/22
 next_date: Nov 22

--- a/content/11/22.md
+++ b/content/11/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/21
 prev_date: Nov 21
 this_url: /westminster-daily/11/22
 short_date: "1122"
+day_number: "326"
 this_date: Nov 22
 next_url: /westminster-daily/11/23
 next_date: Nov 23

--- a/content/11/23.md
+++ b/content/11/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/22
 prev_date: Nov 22
 this_url: /westminster-daily/11/23
 short_date: "1123"
+day_number: "327"
 this_date: Nov 23
 next_url: /westminster-daily/11/24
 next_date: Nov 24

--- a/content/11/24.md
+++ b/content/11/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/23
 prev_date: Nov 23
 this_url: /westminster-daily/11/24
 short_date: "1124"
+day_number: "328"
 this_date: Nov 24
 next_url: /westminster-daily/11/25
 next_date: Nov 25

--- a/content/11/25.md
+++ b/content/11/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/24
 prev_date: Nov 24
 this_url: /westminster-daily/11/25
 short_date: "1125"
+day_number: "329"
 this_date: Nov 25
 next_url: /westminster-daily/11/26
 next_date: Nov 26

--- a/content/11/26.md
+++ b/content/11/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/25
 prev_date: Nov 25
 this_url: /westminster-daily/11/26
 short_date: "1126"
+day_number: "330"
 this_date: Nov 26
 next_url: /westminster-daily/11/27
 next_date: Nov 27

--- a/content/11/27.md
+++ b/content/11/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/26
 prev_date: Nov 26
 this_url: /westminster-daily/11/27
 short_date: "1127"
+day_number: "331"
 this_date: Nov 27
 next_url: /westminster-daily/11/28
 next_date: Nov 28

--- a/content/11/28.md
+++ b/content/11/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/27
 prev_date: Nov 27
 this_url: /westminster-daily/11/28
 short_date: "1128"
+day_number: "332"
 this_date: Nov 28
 next_url: /westminster-daily/11/29
 next_date: Nov 29

--- a/content/11/29.md
+++ b/content/11/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/28
 prev_date: Nov 28
 this_url: /westminster-daily/11/29
 short_date: "1129"
+day_number: "333"
 this_date: Nov 29
 next_url: /westminster-daily/11/30
 next_date: Nov 30

--- a/content/11/30.md
+++ b/content/11/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/29
 prev_date: Nov 29
 this_url: /westminster-daily/11/30
 short_date: "1130"
+day_number: "334"
 this_date: Nov 30
 next_url: /westminster-daily/12/01
 next_date: Dec 1

--- a/content/12/01.md
+++ b/content/12/01.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/11/30
 prev_date: Nov 30
 this_url: /westminster-daily/12/01
 short_date: "1201"
+day_number: "335"
 this_date: Dec 1
 next_url: /westminster-daily/12/02
 next_date: Dec 2

--- a/content/12/02.md
+++ b/content/12/02.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/01
 prev_date: Dec 1
 this_url: /westminster-daily/12/02
 short_date: "1202"
+day_number: "336"
 this_date: Dec 2
 next_url: /westminster-daily/12/03
 next_date: Dec 3

--- a/content/12/03.md
+++ b/content/12/03.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/02
 prev_date: Dec 2
 this_url: /westminster-daily/12/03
 short_date: "1203"
+day_number: "337"
 this_date: Dec 3
 next_url: /westminster-daily/12/04
 next_date: Dec 4

--- a/content/12/04.md
+++ b/content/12/04.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/03
 prev_date: Dec 3
 this_url: /westminster-daily/12/04
 short_date: "1204"
+day_number: "338"
 this_date: Dec 4
 next_url: /westminster-daily/12/05
 next_date: Dec 5

--- a/content/12/05.md
+++ b/content/12/05.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/04
 prev_date: Dec 4
 this_url: /westminster-daily/12/05
 short_date: "1205"
+day_number: "339"
 this_date: Dec 5
 next_url: /westminster-daily/12/06
 next_date: Dec 6

--- a/content/12/06.md
+++ b/content/12/06.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/05
 prev_date: Dec 5
 this_url: /westminster-daily/12/06
 short_date: "1206"
+day_number: "340"
 this_date: Dec 6
 next_url: /westminster-daily/12/07
 next_date: Dec 7

--- a/content/12/07.md
+++ b/content/12/07.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/06
 prev_date: Dec 6
 this_url: /westminster-daily/12/07
 short_date: "1207"
+day_number: "341"
 this_date: Dec 7
 next_url: /westminster-daily/12/08
 next_date: Dec 8

--- a/content/12/08.md
+++ b/content/12/08.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/07
 prev_date: Dec 7
 this_url: /westminster-daily/12/08
 short_date: "1208"
+day_number: "342"
 this_date: Dec 8
 next_url: /westminster-daily/12/09
 next_date: Dec 9

--- a/content/12/09.md
+++ b/content/12/09.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/08
 prev_date: Dec 8
 this_url: /westminster-daily/12/09
 short_date: "1209"
+day_number: "343"
 this_date: Dec 9
 next_url: /westminster-daily/12/10
 next_date: Dec 10

--- a/content/12/10.md
+++ b/content/12/10.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/09
 prev_date: Dec 9
 this_url: /westminster-daily/12/10
 short_date: "1210"
+day_number: "344"
 this_date: Dec 10
 next_url: /westminster-daily/12/11
 next_date: Dec 11

--- a/content/12/11.md
+++ b/content/12/11.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/10
 prev_date: Dec 10
 this_url: /westminster-daily/12/11
 short_date: "1211"
+day_number: "345"
 this_date: Dec 11
 next_url: /westminster-daily/12/12
 next_date: Dec 12

--- a/content/12/12.md
+++ b/content/12/12.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/11
 prev_date: Dec 11
 this_url: /westminster-daily/12/12
 short_date: "1212"
+day_number: "346"
 this_date: Dec 12
 next_url: /westminster-daily/12/13
 next_date: Dec 13

--- a/content/12/13.md
+++ b/content/12/13.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/12
 prev_date: Dec 12
 this_url: /westminster-daily/12/13
 short_date: "1213"
+day_number: "347"
 this_date: Dec 13
 next_url: /westminster-daily/12/14
 next_date: Dec 14

--- a/content/12/14.md
+++ b/content/12/14.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/13
 prev_date: Dec 13
 this_url: /westminster-daily/12/14
 short_date: "1214"
+day_number: "348"
 this_date: Dec 14
 next_url: /westminster-daily/12/15
 next_date: Dec 15

--- a/content/12/15.md
+++ b/content/12/15.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/14
 prev_date: Dec 14
 this_url: /westminster-daily/12/15
 short_date: "1215"
+day_number: "349"
 this_date: Dec 15
 next_url: /westminster-daily/12/16
 next_date: Dec 16

--- a/content/12/16.md
+++ b/content/12/16.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/15
 prev_date: Dec 15
 this_url: /westminster-daily/12/16
 short_date: "1216"
+day_number: "350"
 this_date: Dec 16
 next_url: /westminster-daily/12/17
 next_date: Dec 17

--- a/content/12/17.md
+++ b/content/12/17.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/16
 prev_date: Dec 16
 this_url: /westminster-daily/12/17
 short_date: "1217"
+day_number: "351"
 this_date: Dec 17
 next_url: /westminster-daily/12/18
 next_date: Dec 18

--- a/content/12/18.md
+++ b/content/12/18.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/17
 prev_date: Dec 17
 this_url: /westminster-daily/12/18
 short_date: "1218"
+day_number: "352"
 this_date: Dec 18
 next_url: /westminster-daily/12/19
 next_date: Dec 19

--- a/content/12/19.md
+++ b/content/12/19.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/18
 prev_date: Dec 18
 this_url: /westminster-daily/12/19
 short_date: "1219"
+day_number: "353"
 this_date: Dec 19
 next_url: /westminster-daily/12/20
 next_date: Dec 20

--- a/content/12/20.md
+++ b/content/12/20.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/19
 prev_date: Dec 19
 this_url: /westminster-daily/12/20
 short_date: "1220"
+day_number: "354"
 this_date: Dec 20
 next_url: /westminster-daily/12/21
 next_date: Dec 21

--- a/content/12/21.md
+++ b/content/12/21.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/20
 prev_date: Dec 20
 this_url: /westminster-daily/12/21
 short_date: "1221"
+day_number: "355"
 this_date: Dec 21
 next_url: /westminster-daily/12/22
 next_date: Dec 22

--- a/content/12/22.md
+++ b/content/12/22.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/21
 prev_date: Dec 21
 this_url: /westminster-daily/12/22
 short_date: "1222"
+day_number: "356"
 this_date: Dec 22
 next_url: /westminster-daily/12/23
 next_date: Dec 23

--- a/content/12/23.md
+++ b/content/12/23.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/22
 prev_date: Dec 22
 this_url: /westminster-daily/12/23
 short_date: "1223"
+day_number: "357"
 this_date: Dec 23
 next_url: /westminster-daily/12/24
 next_date: Dec 24

--- a/content/12/24.md
+++ b/content/12/24.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/23
 prev_date: Dec 23
 this_url: /westminster-daily/12/24
 short_date: "1224"
+day_number: "358"
 this_date: Dec 24
 next_url: /westminster-daily/12/25
 next_date: Dec 25

--- a/content/12/25.md
+++ b/content/12/25.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/24
 prev_date: Dec 24
 this_url: /westminster-daily/12/25
 short_date: "1225"
+day_number: "359"
 this_date: Dec 25
 next_url: /westminster-daily/12/26
 next_date: Dec 26

--- a/content/12/26.md
+++ b/content/12/26.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/25
 prev_date: Dec 25
 this_url: /westminster-daily/12/26
 short_date: "1226"
+day_number: "360"
 this_date: Dec 26
 next_url: /westminster-daily/12/27
 next_date: Dec 27

--- a/content/12/27.md
+++ b/content/12/27.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/26
 prev_date: Dec 26
 this_url: /westminster-daily/12/27
 short_date: "1227"
+day_number: "361"
 this_date: Dec 27
 next_url: /westminster-daily/12/28
 next_date: Dec 28

--- a/content/12/28.md
+++ b/content/12/28.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/27
 prev_date: Dec 27
 this_url: /westminster-daily/12/28
 short_date: "1228"
+day_number: "362"
 this_date: Dec 28
 next_url: /westminster-daily/12/29
 next_date: Dec 29

--- a/content/12/29.md
+++ b/content/12/29.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/28
 prev_date: Dec 28
 this_url: /westminster-daily/12/29
 short_date: "1229"
+day_number: "363"
 this_date: Dec 29
 next_url: /westminster-daily/12/30
 next_date: Dec 30

--- a/content/12/30.md
+++ b/content/12/30.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/29
 prev_date: Dec 29
 this_url: /westminster-daily/12/30
 short_date: "1230"
+day_number: "364"
 this_date: Dec 30
 next_url: /westminster-daily/12/31
 next_date: Dec 31

--- a/content/12/31.md
+++ b/content/12/31.md
@@ -5,6 +5,7 @@ prev_url: /westminster-daily/12/30
 prev_date: Dec 30
 this_url: /westminster-daily/12/31
 short_date: "1231"
+day_number: "365"
 this_date: Dec 31
 next_url: /westminster-daily/01/01
 next_date: Jan 1

--- a/static/scss/custom.scss
+++ b/static/scss/custom.scss
@@ -5,6 +5,9 @@ $burgundy: #5C1A2A;
 $gold: #C4A265;
 $brown-muted: #8B7355;
 $brown-light: #A0937D;
+// Both browns above fall under the 4.5:1 AA floor on cream and on the footer
+// background, so any brown carrying actual words uses this one instead.
+$brown-text: #6B5D45;
 $dark-brown: #2C1810;
 $footer-bg: #F5F0E6;
 $border-light: #D6CBAF;
@@ -24,13 +27,29 @@ body {
 }
 
 // === Headings ===
+// Bulma's minireset flattens every heading to font-size: 100%, so without a
+// scale here an h1 renders identically to the paragraph beneath it.
 h1, h2, h3, h4, h5, h6 {
     font-family: Georgia, 'Times New Roman', serif;
     color: $burgundy;
+    line-height: 1.32;
+    margin: 0 0 0.5em 0;
 }
+
+h1 { font-size: 27px; }
+h2 { font-size: 22px; }
+h3 { font-size: 18px; }
+h4 { font-size: 16px; }
+h5, h6 { font-size: 15px; }
 
 h2, h3, h4 {
     font-style: italic;
+}
+
+// Air above a heading that follows something, but not above one that opens
+// the page — the daily reading starts on its "Larger Catechism" label.
+.content-inner {
+    * + h2, * + h3, * + h4 { margin-top: 1.6em; }
 }
 
 // === Links ===
@@ -44,13 +63,29 @@ a {
     }
 }
 
+// Link burgundy is also heading burgundy, so an unlined link inside running
+// prose reads as emphasis rather than as something to click. Navigation rows
+// don't need this — their position already says "link".
+.content-inner p a,
+.content-inner li a {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+}
+
+// An index row whose entire text is the link — the catechism and confession
+// listings — is navigation, not prose. 107 underlined rows is a thicket.
+.content-inner li > a:only-child {
+    text-decoration: none;
+}
+
 // === Masthead ===
 .masthead-label {
     font-family: Georgia, 'Times New Roman', serif;
     font-size: 10px;
     letter-spacing: 3px;
     text-transform: uppercase;
-    color: $brown-light;
+    color: $brown-text;
 }
 
 .masthead-title {
@@ -97,8 +132,56 @@ hr.thin {
 
     small {
         font-family: Georgia, 'Times New Roman', serif;
-        color: $brown-muted;
+        color: $brown-text;
     }
+}
+
+// === Date / Week Navigation ===
+// Yesterday, today, tomorrow used to render identically, so the row never
+// said which one you were reading. Today is the anchor; the neighbours recede.
+.date-nav {
+    font-family: Georgia, 'Times New Roman', serif;
+
+    .date-nav__adjacent {
+        font-size: 15px;
+        color: $brown-text;
+
+        &:hover {
+            color: $burgundy;
+        }
+    }
+
+    .date-nav__current {
+        font-size: 18px;
+        font-weight: bold;
+        color: $burgundy;
+    }
+
+    .date-nav__sep {
+        color: $gold;
+        padding: 0 10px;
+    }
+}
+
+// Where you are in the year. The email carries this line too, and the Start
+// Here page promises it: "Every reading carries a day number."
+.day-number {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 12px;
+    letter-spacing: 1px;
+    color: $brown-text;
+}
+
+// === Audio Label ===
+// The player is a bare play button on a hairline; without a label nothing
+// says the reading is also spoken.
+.audio-label {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 11px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: $brown-text;
+    margin-bottom: 6px;
 }
 
 // === Paragraph Spacing ===
@@ -191,8 +274,8 @@ div.esv {
 
     a {
         font-family: Georgia, 'Times New Roman', serif;
-        font-size: 11px;
-        color: $brown-muted;
+        font-size: 12px;
+        color: $brown-text;
         text-decoration: none;
 
         &:hover {
@@ -205,11 +288,13 @@ div.esv {
         padding: 0 6px;
     }
 
+    // Was 10px #A0937D on #F5F0E6 — 2.7:1, well under AA, for the text that
+    // carries the Pipa attribution and the Crossway permission notice.
     p {
         font-family: Georgia, 'Times New Roman', serif;
-        font-size: 10px;
-        color: $brown-light;
-        line-height: 1.6;
+        font-size: 12px;
+        color: $brown-text;
+        line-height: 1.65;
     }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -164,15 +164,18 @@
                     </div>
 
                     $if(this_url)$
-                    <!-- Navigation -->
-                    <div class="has-text-centered" style="padding: 16px 24px 16px 24px;">
-                        <strong>
-                            <a href="$prev_url$">< $prev_date$</a>
-                            &middot;
-                            <a href="$this_url$">$this_date$</a>
-                            &middot;
-                            <a href="$next_url$">$next_date$ ></a>
-                        </strong>
+                    <!-- Navigation. Today is a span, not a link: it is the page
+                         you are already on, and the weight marks your place. -->
+                    <div class="has-text-centered date-nav" style="padding: 16px 24px 6px 24px;">
+                        <a class="date-nav__adjacent" href="$prev_url$">&lsaquo;&nbsp;$prev_date$</a>
+                        <span class="date-nav__sep">&middot;</span>
+                        <span class="date-nav__current">$this_date$</span>
+                        <span class="date-nav__sep">&middot;</span>
+                        <a class="date-nav__adjacent" href="$next_url$">$next_date$&nbsp;&rsaquo;</a>
+                    </div>
+
+                    <div class="has-text-centered day-number" style="padding: 0 24px 14px 24px;">
+                        Day $day_number$ of 365
                     </div>
 
                     <!-- Mid-year arrivals land on an arbitrary day with no
@@ -214,6 +217,7 @@
                     </div>
 
                     <div style="padding: 0 24px 24px 24px;">
+                        <div class="audio-label">Listen to today&rsquo;s reading</div>
                         <div class="essential_audio" data-url="https://s3.amazonaws.com/www.reformedconfessions.com/westminster-daily/static/audio/$short_date$.mp3"></div>
                     </div>
                     $endif$

--- a/templates/heidelberg-base.html
+++ b/templates/heidelberg-base.html
@@ -160,15 +160,14 @@
                     </div>
 
                     $if(this_url)$
-                    <!-- Navigation -->
-                    <div class="has-text-centered" style="padding: 16px 24px 16px 24px;">
-                        <strong>
-                            <a href="$prev_url$">< $prev_week$</a>
-                            &middot;
-                            <a href="$this_url$">$this_week$</a>
-                            &middot;
-                            <a href="$next_url$">$next_week$ ></a>
-                        </strong>
+                    <!-- Navigation. Same treatment as the daily site: the week
+                         you are reading is a span, and the neighbours recede. -->
+                    <div class="has-text-centered date-nav" style="padding: 16px 24px 16px 24px;">
+                        <a class="date-nav__adjacent" href="$prev_url$">&lsaquo;&nbsp;$prev_week$</a>
+                        <span class="date-nav__sep">&middot;</span>
+                        <span class="date-nav__current">$this_week$</span>
+                        <span class="date-nav__sep">&middot;</span>
+                        <a class="date-nav__adjacent" href="$next_url$">$next_week$&nbsp;&rsaquo;</a>
                     </div>
                     $endif$
 

--- a/templates/newsletter-buttondown.html
+++ b/templates/newsletter-buttondown.html
@@ -11,11 +11,14 @@
           <td style="padding: 4px;">
             <table cellpadding="0" cellspacing="0" border="0" width="100%" style="border: 1px solid #D6CBAF;">
 
-              <!-- Read on web link (top) -->
+              <!-- Read on web link (top). The proof texts run long and many
+                   readers never reach the bottom, so this copy has to carry
+                   the click: legible size, AA contrast, underlined, and padded
+                   out to a thumb-sized tap target. -->
               <tr>
-                <td align="center" style="padding: 26px 24px 0 24px;">
-                  <a href="__ENTRY_URL__" target="_blank" style="font-family: Georgia, 'Times New Roman', serif; font-size: 10px; letter-spacing: 3px; text-transform: uppercase; color: #8B7355; text-decoration: none;">
-                    <span style="color: #C4A265;">∙</span>&nbsp;&nbsp;Read on the web&nbsp;&nbsp;<span style="color: #C4A265;">∙</span>
+                <td align="center" style="padding: 22px 24px 0 24px;">
+                  <a href="__ENTRY_URL__" target="_blank" style="display: inline-block; padding: 6px 8px; font-family: Georgia, 'Times New Roman', serif; font-size: 13px; letter-spacing: 1.5px; text-transform: uppercase; color: #6B4423; text-decoration: none;">
+                    <span style="color: #C4A265;">∙</span>&nbsp;&nbsp;<span style="text-decoration: underline;">Read on the web</span>&nbsp;&nbsp;<span style="color: #C4A265;">∙</span>
                   </a>
                 </td>
               </tr>
@@ -36,9 +39,9 @@
 
               <!-- Read on web link (bottom) -->
               <tr>
-                <td align="center" style="padding: 0 24px 26px 24px;">
-                  <a href="__ENTRY_URL__" target="_blank" style="font-family: Georgia, 'Times New Roman', serif; font-size: 10px; letter-spacing: 3px; text-transform: uppercase; color: #8B7355; text-decoration: none;">
-                    <span style="color: #C4A265;">∙</span>&nbsp;&nbsp;Read on the web&nbsp;&nbsp;<span style="color: #C4A265;">∙</span>
+                <td align="center" style="padding: 0 24px 22px 24px;">
+                  <a href="__ENTRY_URL__" target="_blank" style="display: inline-block; padding: 6px 8px; font-family: Georgia, 'Times New Roman', serif; font-size: 13px; letter-spacing: 1.5px; text-transform: uppercase; color: #6B4423; text-decoration: none;">
+                    <span style="color: #C4A265;">∙</span>&nbsp;&nbsp;<span style="text-decoration: underline;">Read on the web</span>&nbsp;&nbsp;<span style="color: #C4A265;">∙</span>
                   </a>
                 </td>
               </tr>


### PR DESCRIPTION
Six fixes from a design review of the rendered pages. Each was verified in the browser against a local build.

### Site

- **Heading scale.** Bulma's minireset sets `h1..h6` to `font-size: 100%` and `custom.scss` never restored a scale, so every heading on the site rendered at 16px — identical to body text. On the catechism indexes the page title and the paragraph beneath it were the same size.
- **Contrast.** The footer copyright was 10px `#A0937D` on `#F5F0E6` — **2.7:1**, well under the 4.5:1 AA floor — and it carries the Pipa attribution and the Crossway permission notice. Footer links (4.0:1) and the masthead label (3.0:1) failed too. All browns that carry words now use `#6B5D45`.
- **Prose links.** The global rule strips underlines and link burgundy is heading burgundy, so a link inside a paragraph read as emphasis. Prose links are underlined; index rows whose entire text is the link (`li > a:only-child`) stay clean, so the 107-row catechism listing doesn't become a thicket.
- **Date navigation.** Yesterday, today, and tomorrow rendered identically. Today is now the anchor and is no longer a link to the page you're already on. Same treatment on Heidelberg Weekly.
- **Day number.** The email carries "Day 215 of 365" and the Start Here page promises every reading has one, but the web page didn't show it. Every daily source file gets a `day_number`, computed with the same fixed table `worker/src/index.js` uses for the email subject, so the two can't drift.
- **Audio label.** The player was an unlabeled play button on a hairline.

### Build

`build/css/main.css` depended only on `main.scss`, which is fifteen lines of imports. Editing `custom.scss` left the built stylesheet stale — a full `make` shipped the old CSS. It now depends on every partial. This bit me during this change.

### Email

Also included: the earlier commit making the "Read on the web" link legible (13px, 8.3:1, underlined, thumb-sized tap target) in place of 10px at 4.4:1 with no underline.

### Not changed

The footnote markers and the `toggle proof texts` button are left as they are.

Verified with `make all` (370 daily pages, 339 reference, 55 Heidelberg) and by inspecting the daily reading, Start Here, the Shorter Catechism index, and the footer in the browser.