### PR TITLE
Deploy the email worker when the newsletter template changes

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -5,6 +5,11 @@ on:
     branches: [master]
     paths:
       - "worker/**"
+      # The email body lives here, not under worker/. worker/src/template.html
+      # is a gitignored copy that `npm ci` regenerates via the prepare script,
+      # so without this path an edit to the newsletter template would sit
+      # unshipped until something else in worker/ happened to change.
+      - "templates/newsletter-buttondown.html"
       - ".github/workflows/deploy-worker.yml"
   workflow_dispatch: {}
 
@@ -22,6 +27,13 @@ jobs:
       - name: Install worker dependencies
         working-directory: worker
         run: npm ci
+
+      # npm ci already runs this through the prepare hook. Doing it explicitly
+      # keeps the pipeline readable and means the deploy does not depend on a
+      # lifecycle script staying wired up.
+      - name: Sync the newsletter template into the worker
+        working-directory: worker
+        run: npm run sync-template
 
       - name: Deploy worker
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
`deploy-worker.yml` only fired on `worker/**`, but the email body lives at `templates/newsletter-buttondown.html` — `worker/src/template.html` is a gitignored copy that `npm ci` regenerates through the `prepare` script.

So a change to the email template landed on master and never shipped. Today's link fix (merged in #24) is sitting undeployed: the last worker deploy was August 1 at `4eac235`, and tomorrow's send would have gone out with the old 10px link.

Two changes:

- Add `templates/newsletter-buttondown.html` to the trigger paths.
- Make the template sync an explicit step instead of relying on the `prepare` lifecycle hook.

Merging this triggers a worker deploy (the workflow file is in its own path filter), which picks up the pending template change.