### PR TITLE
Define the palette by role, and retire the colours that fail

### DIFF
--- a/static/scss/custom.scss
+++ b/static/scss/custom.scss
@@ -1,12 +1,25 @@
 // === Color Palette (from newsletter) ===
+//
+// Roles, not a swatch box. Every colour below has one job and a contrast
+// floor, because the palette's failure mode is expressing "quiet" as
+// "lighter" until it stops being readable. Quiet is size, weight, and
+// letter-spacing; it is never a value above L*50.
+//
+//   ink         body copy                    16.6:1 on cream
+//   accent      headings and links           12.6:1 on cream
+//   ink-muted   ALL secondary text, any size  6.3:1 on cream, 4.9:1 on parchment
+//   ornament    rules and flourishes          decorative only, NEVER text
+//   edge        borders                       decorative
+//   surfaces    cream (page), parchment (recessed)
+//
 $parchment: #E8E0D2;
 $cream: #FFFDF7;
 $burgundy: #5C1A2A;
 $gold: #C4A265;
-$brown-muted: #8B7355;
-$brown-light: #A0937D;
-// Both browns above fall under the 4.5:1 AA floor on cream and on the footer
-// background, so any brown carrying actual words uses this one instead.
+// #8B7355 (4.41:1 on cream — under AA by 0.09) and #A0937D (2.96:1) used to
+// live here as $brown-muted and $brown-light. Every element that used them
+// now uses $brown-text, so they are gone rather than sitting around waiting
+// to be picked up again.
 $brown-text: #6B5D45;
 $dark-brown: #2C1810;
 $footer-bg: #F5F0E6;
@@ -108,7 +121,7 @@ a {
 .masthead-subtitle {
     font-family: Georgia, 'Times New Roman', serif;
     font-size: 14px;
-    color: $brown-muted;
+    color: $brown-text;
     font-style: italic;
 }
 
@@ -266,8 +279,10 @@ div.esv {
 }
 
 // === Footer ===
+// The fill used to be $footer-bg, 1.12:1 against the cream page — a panel
+// nobody could see, carried entirely by its own border. The rule does the
+// work; the fill was paying rent for nothing.
 .site-footer {
-    background-color: $footer-bg;
     border-top: 1px solid $border-light;
     padding: 1.5em;
     text-align: center;
@@ -298,10 +313,52 @@ div.esv {
     }
 }
 
+// === Email Signup ===
+// The one part of the design that was not from this palette: #666 body text
+// and a #3c3c3c button, the only cool neutrals among fifteen warm colours.
+// Both passed contrast; both read as pasted in from another site. Parchment
+// also gives the box a value step you can actually see (1.29:1 against the
+// page, where the old #FAF7F0 was 1.05:1).
+.email-signup {
+    background-color: $parchment;
+    border: 1px solid $border-light;
+
+    .email-signup__title {
+        font-weight: bold;
+        color: $dark-brown;
+        margin-bottom: 12px;
+    }
+
+    .email-signup__blurb {
+        font-size: 0.9em;
+        color: $brown-text;
+        margin-bottom: 16px;
+    }
+
+    input[type="email"] {
+        font-family: Georgia, 'Times New Roman', serif;
+        border: 1px solid $border-light;
+        background-color: $cream;
+        color: $dark-brown;
+    }
+
+    input[type="submit"] {
+        font-family: Georgia, 'Times New Roman', serif;
+        background-color: $burgundy;
+        color: #fff;
+        border: none;
+        cursor: pointer;
+
+        &:hover {
+            background-color: #3d1019;
+        }
+    }
+}
+
 // === Collapsible Sections ===
 .collapsible {
     background-color: $cream;
-    color: $brown-muted;
+    color: $brown-text;
     cursor: pointer;
     padding: 8px;
     width: 100%;

--- a/templates/base.html
+++ b/templates/base.html
@@ -252,9 +252,9 @@
                     </div>
 
                     <!-- Email signup -->
-                    <div class="email-signup" style="padding: 24px; margin: 16px 24px; border: 1px solid #e0d9c7; border-radius: 4px; background: #faf7f0; text-align: center;">
-                        <p style="margin: 0 0 12px 0; font-weight: bold;">Get Westminster Daily in your inbox</p>
-                        <p style="margin: 0 0 16px 0; font-size: 0.9em; color: #666;">A short daily reading from the Westminster Standards, delivered each morning.</p>
+                    <div class="email-signup" style="padding: 24px; margin: 16px 24px; border-radius: 4px; text-align: center;">
+                        <p class="email-signup__title">Get Westminster Daily in your inbox</p>
+                        <p class="email-signup__blurb">A short daily reading from the Westminster Standards, delivered each morning.</p>
                         <form
                             action="https://buttondown.com/api/emails/embed-subscribe/reformedconfessions"
                             method="post"
@@ -265,9 +265,9 @@
                         >
                             <label for="bd-email" style="position: absolute; left: -9999px;">Enter your email</label>
                             <input type="email" name="email" id="bd-email" placeholder="your@email.com" required
-                                style="flex: 1 1 220px; max-width: 320px; padding: 8px 12px; border: 1px solid #ccc; border-radius: 3px; font-size: 1em;" />
+                                style="flex: 1 1 220px; max-width: 320px; padding: 8px 12px; border-radius: 3px; font-size: 1em;" />
                             <input type="submit" value="Subscribe"
-                                style="padding: 8px 20px; background: #3c3c3c; color: #fff; border: none; border-radius: 3px; font-size: 1em; cursor: pointer;" />
+                                style="padding: 8px 20px; border-radius: 3px; font-size: 1em;" />
                         </form>
                     </div>
 

--- a/templates/newsletter-buttondown.html
+++ b/templates/newsletter-buttondown.html
@@ -25,7 +25,7 @@
 
               <!-- Where you are in the year -->
               <tr>
-                <td align="center" style="padding: 10px 24px 0 24px; font-family: Georgia, 'Times New Roman', serif; font-size: 11px; color: #A89878;">
+                <td align="center" style="padding: 10px 24px 0 24px; font-family: Georgia, 'Times New Roman', serif; font-size: 11px; color: #6B5D45;">
                   Day __DAY_NUMBER__ of 365
                 </td>
               </tr>
@@ -50,8 +50,8 @@
               <tr>
                 <td align="center" style="border-top: 1px solid #D6CBAF; padding: 18px 24px 16px 24px; font-family: Georgia, 'Times New Roman', serif; font-size: 13px; line-height: 1.7; color: #6B5D45;">
                   Share today's reading with your family or your small group:<br />
-                  <a href="__ENTRY_URL__" style="color: #8B7355;">__ENTRY_URL__</a>
-                  <div style="padding-top: 12px; font-size: 12px; color: #8B7355;">
+                  <a href="__ENTRY_URL__" style="color: #6B5D45;">__ENTRY_URL__</a>
+                  <div style="padding-top: 12px; font-size: 12px; color: #6B5D45;">
                     Forwarded this?
                     <a href="https://buttondown.com/reformedconfessions" style="color: #8B5A2B; font-weight: bold; text-decoration: underline;">Get it every morning &rarr;</a>
                   </div>
@@ -60,12 +60,12 @@
 
               <!-- Site links -->
               <tr>
-                <td align="center" style="border-top: 1px solid #D6CBAF; background-color: #F5F0E6; padding: 18px 24px 18px 24px;">
-                  <a href="https://reformeddeacon.com" style="font-family: Georgia, 'Times New Roman', serif; font-size: 11px; color: #8B7355; text-decoration: none;">reformeddeacon.com</a>
+                <td align="center" style="border-top: 1px solid #D6CBAF; padding: 18px 24px 18px 24px;">
+                  <a href="https://reformeddeacon.com" style="font-family: Georgia, 'Times New Roman', serif; font-size: 11px; color: #6B5D45; text-decoration: none;">reformeddeacon.com</a>
                   <span style="color: #C4A265; padding: 0 6px;">·</span>
-                  <a href="https://ulsterworldly.com/" style="font-family: Georgia, 'Times New Roman', serif; font-size: 11px; color: #8B7355; text-decoration: none;">ulsterworldly.com</a>
+                  <a href="https://ulsterworldly.com/" style="font-family: Georgia, 'Times New Roman', serif; font-size: 11px; color: #6B5D45; text-decoration: none;">ulsterworldly.com</a>
                   <span style="color: #C4A265; padding: 0 6px;">·</span>
-                  <a href="https://readmachen.com/" style="font-family: Georgia, 'Times New Roman', serif; font-size: 11px; color: #8B7355; text-decoration: none;">readmachen.com</a>
+                  <a href="https://readmachen.com/" style="font-family: Georgia, 'Times New Roman', serif; font-size: 11px; color: #6B5D45; text-decoration: none;">readmachen.com</a>
                 </td>
               </tr>
 


### PR DESCRIPTION
Follow-up to the readability pass, from measuring every foreground/background pair both designs actually use.

## The pattern

The palette encoded *quiet* as *lighter*. Seven of fifteen colours sat above L\*60, and past a point lighter just means unreadable — so every secondary element reached for a tan that missed AA. `#8B7355` was the cruel one: **4.41:1**, under the floor by 0.09. `#A0937D` was **2.96:1**.

Both are gone. Everything that used them now uses `#6B5D45` (6.3:1 on cream, 4.9:1 on parchment), and quiet is carried by size, weight, and letter-spacing — which the design already does well; the 10px tracked uppercase labels read as quiet even in a dark brown.

Fixed with them, all in the email: day counter **2.78:1**, footnote superscripts **4.41:1**, footer site links **3.95:1**.

## Two surfaces that weren't surfaces

| | before | after |
|---|---|---|
| site footer fill vs page | 1.12:1 | fill removed, rule does the work |
| signup box fill vs page | 1.05:1 | parchment, **1.29:1** |
| email footer band vs page | 1.12:1 | fill removed |

Both panels were invisible and carried entirely by their own 1px borders.

## The one off-palette element

The signup box used `#666` body text and a `#3c3c3c` button — the only cool neutrals among fifteen warm colours (all others sit between 27° and 45°). Both passed contrast; this was a cohesion failure, not a legibility one. On a parchment page a grey button reads as pasted in from another website. Now parchment, burgundy, and ink, with the styling moved out of inline attributes into the stylesheet.

## Result

**Zero** text-carrying pairs under 4.5:1 in either design, down from six. Gold (2.37:1) and the borders (1.59:1) stay exactly as they are — decorative, and the palette comment now states the rule that keeps them that way: *ornament never carries meaning.*

The role table is written into the top of `custom.scss` so "is there enough contrast" stops being a per-element judgment call.

Verified by rebuilding and inspecting the daily reading, the footer, the signup box, and a full email render with today's proof texts.