### PR TITLE
Take 70px of chrome off the top of every reading

### DIFF
--- a/static/scss/custom.scss
+++ b/static/scss/custom.scss
@@ -93,17 +93,24 @@ a {
 }
 
 // === Masthead ===
+// Display type set on the body's 1.78 leading wastes about 15px above the
+// reading for no gain. Both lines are blocks so their own line-height governs
+// the row rather than the wrapper's.
 .masthead-label {
+    display: block;
     font-family: Georgia, 'Times New Roman', serif;
     font-size: 10px;
+    line-height: 1.4;
     letter-spacing: 3px;
     text-transform: uppercase;
     color: $brown-text;
 }
 
 .masthead-title {
+    display: block;
     font-family: Georgia, 'Times New Roman', serif;
     font-size: 20px;
+    line-height: 1.2;
     letter-spacing: 3px;
     text-decoration: none;
     color: $dark-brown;
@@ -178,11 +185,16 @@ hr.thin {
 
 // Where you are in the year. The email carries this line too, and the Start
 // Here page promises it: "Every reading carries a day number."
+//
+// It sits inside .date-nav rather than in a row of its own: the date and the
+// day number are one thought, and splitting them cost 35px above the reading.
 .day-number {
     font-family: Georgia, 'Times New Roman', serif;
     font-size: 12px;
+    line-height: 1.4;
     letter-spacing: 1px;
     color: $brown-text;
+    margin-top: 3px;
 }
 
 // === Audio Label ===

--- a/templates/base.html
+++ b/templates/base.html
@@ -151,10 +151,10 @@
                 <div class="content-inner">
 
                     <!-- Masthead -->
-                    <div class="has-text-centered" style="padding: 30px 24px 10px 24px;">
+                    <div class="has-text-centered" style="padding: 24px 24px 4px 24px;">
                         <span class="masthead-label">A Daily Reading from the</span>
                     </div>
-                    <div class="has-text-centered" style="padding: 0 24px 22px 24px;">
+                    <div class="has-text-centered" style="padding: 0 24px 14px 24px;">
                         <span class="masthead-title"><a href="/westminster-daily/">WESTMINSTER STANDARDS</a></span>
                     </div>
 
@@ -166,21 +166,18 @@
                     $if(this_url)$
                     <!-- Navigation. Today is a span, not a link: it is the page
                          you are already on, and the weight marks your place. -->
-                    <div class="has-text-centered date-nav" style="padding: 16px 24px 6px 24px;">
+                    <div class="has-text-centered date-nav" style="padding: 12px 24px 10px 24px;">
                         <a class="date-nav__adjacent" href="$prev_url$">&lsaquo;&nbsp;$prev_date$</a>
                         <span class="date-nav__sep">&middot;</span>
                         <span class="date-nav__current">$this_date$</span>
                         <span class="date-nav__sep">&middot;</span>
                         <a class="date-nav__adjacent" href="$next_url$">$next_date$&nbsp;&rsaquo;</a>
-                    </div>
-
-                    <div class="has-text-centered day-number" style="padding: 0 24px 14px 24px;">
-                        Day $day_number$ of 365
+                        <div class="day-number">Day $day_number$ of 365</div>
                     </div>
 
                     <!-- Mid-year arrivals land on an arbitrary day with no
                          context. Say plainly that starting today works. -->
-                    <div class="has-text-centered" style="padding: 0 24px 14px 24px;">
+                    <div class="has-text-centered" style="padding: 0 24px 10px 24px;">
                         <small>
                             New here?
                             <a href="/westminster-daily/start">Start today</a>
@@ -195,7 +192,7 @@
                     </div>
 
                     <!-- Reading content -->
-                    <div style="padding: 22px 24px 30px 24px;">
+                    <div style="padding: 18px 24px 30px 24px;">
                         $if(own_heading)$
                         $else$
                         $if(short_date)$

--- a/templates/heidelberg-base.html
+++ b/templates/heidelberg-base.html
@@ -147,10 +147,10 @@
                 <div class="content-inner">
 
                     <!-- Masthead -->
-                    <div class="has-text-centered" style="padding: 30px 24px 10px 24px;">
+                    <div class="has-text-centered" style="padding: 24px 24px 4px 24px;">
                         <span class="masthead-label">A Weekly Reading from the</span>
                     </div>
-                    <div class="has-text-centered" style="padding: 0 24px 22px 24px;">
+                    <div class="has-text-centered" style="padding: 0 24px 14px 24px;">
                         <span class="masthead-title"><a href="/heidelberg-weekly/">HEIDELBERG CATECHISM</a></span>
                     </div>
 


### PR DESCRIPTION
Measured, not eyeballed: the masthead, date row, day counter, and newcomer line put **304px** above the first word of the reading — about **47% of the first screen on a phone**. The masthead alone was 126px, 48% of that, for two short lines of type.

Three changes, nothing removed or moved:

| | before | after |
|---|---|---|
| masthead block | 126px | **80px** |
| date row + day counter | 89px (two rows) | **74px** (one) |
| newcomer line | 42px | 38px |
| **reading starts at** | **304px** | **234px** |

- **Masthead leading.** It was set on the body's 1.78, which is reading leading, not display leading. Both lines are now blocks so their own line-height governs the row. That alone recovers 15px.
- **Masthead padding**, but not at the top. The first pass cut the head margin to 16px and it read as cramped — a printed page needs air at the head, and that's the last place to economise. It sits at 30px from the card edge.
- **The day counter joins the nav block.** The date and the day number are one thought; splitting them across two rows cost 35px.

The newcomer line stays where it is. It's the biggest single cost on a phone (~69px, since it wraps to three lines), but it's aimed at first-time visitors, who are most of the site's traffic — the regulars are on the email and the podcast. Moving it below the reading remains available if you want another ~69px.

Heidelberg Weekly gets the same masthead treatment so the two don't drift.

Phone estimate after: ~265px, down from ~312px.