### PR TITLE
Style the reference pages, which shipped with no CSS at all

### DIFF
--- a/scripts/generate_reference_content.py
+++ b/scripts/generate_reference_content.py
@@ -219,12 +219,13 @@ def render_item(abbv: str, record: dict, prev_rec, next_rec) -> str:
             f"<h2>Question {html.escape(key)}</h2>"
         )
 
+    # Guillemets and gold separators, matching the daily site's date row.
     nav = []
     if prev_rec:
         label = "Chapter" if abbv == "wcf" else "Q"
         sep = " " if abbv == "wcf" else ""
         nav.append(
-            f'<a href="/{slug}/{prev_rec["key"]}/">&lt; {label}{sep}{prev_rec["key"]}</a>'
+            f'<a href="/{slug}/{prev_rec["key"]}/">&lsaquo;&nbsp;{label}{sep}{prev_rec["key"]}</a>'
         )
     unit = "chapters" if abbv == "wcf" else "questions"
     nav.append(f'<a href="/{slug}/">All {unit}</a>')
@@ -232,11 +233,10 @@ def render_item(abbv: str, record: dict, prev_rec, next_rec) -> str:
         label = "Chapter" if abbv == "wcf" else "Q"
         sep = " " if abbv == "wcf" else ""
         nav.append(
-            f'<a href="/{slug}/{next_rec["key"]}/">{label}{sep}{next_rec["key"]} &gt;</a>'
+            f'<a href="/{slug}/{next_rec["key"]}/">{label}{sep}{next_rec["key"]}&nbsp;&rsaquo;</a>'
         )
-    nav_html = (
-        '<div class="reference-nav">' + " &middot; ".join(nav) + "</div>"
-    )
+    joiner = '<span class="reference-nav__sep">&middot;</span>'
+    nav_html = '<div class="reference-nav">' + joiner.join(nav) + "</div>"
 
     meta = front_matter(
         pagetitle.replace('"', "'"),

--- a/static/scss/custom.scss
+++ b/static/scss/custom.scss
@@ -240,6 +240,96 @@ hr.thin {
     font-family: Georgia, 'Times New Roman', serif;
 }
 
+// === Reference Pages ===
+// The 339 per-question and per-chapter pages. Their generator emits nine
+// classes and, until now, the stylesheet defined none of them, so confession
+// paragraphs stacked with no space between them and the trailing prose ran
+// straight into the text of the last one.
+
+// Confession paragraphs. Numbered, hanging indent, and separated.
+.wcf-paragraph {
+    margin-bottom: 1.1em;
+    padding-left: 1.9em;
+    text-indent: -1.9em;
+
+    &:last-of-type {
+        margin-bottom: 0;
+    }
+}
+
+.paragraph-number {
+    color: $burgundy;
+    font-weight: bold;
+    padding-right: 0.35em;
+}
+
+// Catechism question and answer.
+.reference-qa {
+    .q {
+        margin-bottom: 0.7em;
+    }
+
+    .a {
+        margin-bottom: 0;
+        padding-left: 1.9em;
+        text-indent: -1.9em;
+    }
+
+    .q-label {
+        color: $burgundy;
+        font-weight: bold;
+        padding-right: 0.35em;
+    }
+}
+
+// "Read on February 10, ... in the Westminster Daily plan." A pointer back to
+// the calendar, not part of the text it follows, so it gets a rule and air.
+.reference-dates {
+    margin-top: 1.8em;
+    padding-top: 1.1em;
+    border-top: 1px solid $border-light;
+    font-size: 15px;
+    color: $brown-text;
+
+    a {
+        color: $burgundy;
+    }
+}
+
+.reference-blurb {
+    margin-bottom: 1.25em;
+}
+
+// Chapter and question navigation. Matches the daily site's date row, minus
+// the current-position emphasis: here the heading already says where you are.
+.reference-nav {
+    margin-top: 1.8em;
+    font-family: Georgia, 'Times New Roman', serif;
+    text-align: center;
+
+    a {
+        font-size: 15px;
+        color: $brown-text;
+
+        &:hover {
+            color: $burgundy;
+        }
+    }
+
+    .reference-nav__sep {
+        color: $gold;
+        padding: 0 10px;
+    }
+}
+
+.reference-index {
+    margin-top: 1.5em;
+
+    li {
+        margin-bottom: 0.75em;
+    }
+}
+
 .image {
     background-color: white;
     border-left: 4px solid $border-light;


### PR DESCRIPTION
`/westminster-confession/5/` needed spacing because **nine of the ten classes its generator emits were never defined in the stylesheet**:

```
wcf-paragraph      0        reference-blurb    0
paragraph-number   0        reference-dates    0
reference-qa       0        reference-index    0
q-label            0        reference-nav      0
a                  0        q                  1  ← the only one
```

So all 339 per-question and per-chapter pages have been rendering as raw markup. Confession paragraphs were unspaced `div`s with their numbers inline in the prose, and the "Read on February 10, …" pointer ran straight into the last paragraph's text with nothing separating them.

- **Confession paragraphs**: hanging indent off the number, 1.1em between them, number in accent burgundy.
- **Q and A**: same hanging indent, matching labels.
- **The calendar pointer**: a rule and 1.8em above it. It's a cross-reference back to the daily plan, not part of the text it follows.
- **Chapter/question navigation**: now matches the daily site — `‹` and `›` in place of ASCII angle brackets, gold separators, ink-muted links.

Every colour and size comes from the `DESIGN.md` roles, which is the first change to use it as a reference rather than a record.

Checked against a 7-paragraph confession chapter, a short catechism answer, and a long one (LC 125) for the hanging indent.